### PR TITLE
fix: Disable localeDetection in next-intl routing config

### DIFF
--- a/apps/storefront/src/i18n/routing.ts
+++ b/apps/storefront/src/i18n/routing.ts
@@ -17,15 +17,12 @@ export const localePrefixes: Record<
 export const routing = defineRouting({
   locales: SUPPORTED_LOCALES,
   defaultLocale: DEFAULT_LOCALE,
+  localeDetection: false,
   localePrefix: {
     mode: "as-needed",
     prefixes: localePrefixes,
   },
 });
 
-const { redirect: _redirect } = createNavigation(routing);
-
-// Help TypeScript detect unreachable code
-export const redirect: typeof _redirect = _redirect;
-
-export const { Link, usePathname, useRouter } = createNavigation(routing);
+export const { Link, redirect, usePathname, useRouter } =
+  createNavigation(routing);


### PR DESCRIPTION
This fixes the issue of unwanted redirects from `/` to the latest visited/saved locale e.g. `'/gb`.