### PR TITLE
Fix: Ensure grid layout remains consistent for long product names

### DIFF
--- a/apps/storefront/src/components/search-product-card.tsx
+++ b/apps/storefront/src/components/search-product-card.tsx
@@ -26,7 +26,7 @@ export const ProductPrice = ({ children }: PropsWithChildren) => {
 };
 
 export const ProductThumbnail = ({ alt, ...props }: ImageProps) => (
-  <div className="flex aspect-square justify-center">
+  <div className="flex aspect-square justify-center overflow-hidden">
     <Image alt={alt} className="min-w-full object-cover" {...props} />
   </div>
 );


### PR DESCRIPTION
I want to merge this change because it fixes an issue with the product grid when the product name consists of more characters. When the product name is long, the product grid does not display correctly. Adding the hidden parameter to the product thumbnail ensures that products with long names do not 'stretch' in the grid. This change improves the user interface by ensuring that long product names do not cause layout issues, resulting in a more consistent and user-friendly product grid display.

Before: 
<img width="597" alt="image" src="https://github.com/user-attachments/assets/51ed9c7e-617f-46e3-9c0e-6f809a7ce128" />



After: 
<img width="578" alt="image" src="https://github.com/user-attachments/assets/362d097b-3bcb-453b-a0c5-7243b1192a0a" />


<!-- Please mention all relevant issue numbers. -->

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Test the changes locally to ensure they work as expected.
- [ ] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [ ] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [ ] Update documentation to reflect any changes in functionality.
