### PR TITLE
fix: Fix PLP previous button behaviour

### DIFF
--- a/packages/infrastructure/src/public/saleor/search/infrastructure/search-infra.ts
+++ b/packages/infrastructure/src/public/saleor/search/infrastructure/search-infra.ts
@@ -27,11 +27,12 @@ export const saleorSearchInfra =
     },
     context,
   ) => {
+    // Last and first cannot be combined in the same query
     const pageInfo = before
-      ? { before, last: limit }
+      ? { before, last: limit, first: undefined }
       : after
-        ? { after, first: limit }
-        : { first: limit };
+        ? { after, first: limit, last: undefined }
+        : { first: limit, last: undefined };
     // TODO: Find a better way how to handle filters between providers
     const attributesFilter: AttributeInput[] | undefined = filters
       ? Object.entries(filters).map(([slug, value]) => ({
@@ -61,9 +62,7 @@ export const saleorSearchInfra =
             filter: {
               attributes: attributesFilter,
             },
-            first: limit,
             languageCode: context.languageCode as LanguageCodeEnum,
-            last: null,
             search: query,
             searchByCategory: Boolean(category),
             searchByCollection: Boolean(collection),


### PR DESCRIPTION
I want to merge this change because it fixes PLP previous button behaviour - when user clicks `Previous` on pagination products are visible instead of displaying `No results` message.

<!-- Please mention all relevant issue numbers. -->

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Test the changes locally to ensure they work as expected.
- [ ] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [ ] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [ ] Update documentation to reflect any changes in functionality.
