### PR TITLE
fix: Fix wrong redirection on navbar links

### DIFF
--- a/packages/infrastructure/src/lib/serializers/cms-menu.ts
+++ b/packages/infrastructure/src/lib/serializers/cms-menu.ts
@@ -18,7 +18,7 @@ const createMenuItemUrl = (
   locale?: string,
 ): string => {
   const baseUrl = locale
-    ? `${process.env.BASE_URL}/${locale}`
+    ? `${process.env.BASE_URL}${locale}`
     : process.env.BASE_URL;
 
   if (page?.slug) {


### PR DESCRIPTION
I want to merge this change because it fixes redirection on navbar links - when user click on collection using not default locale error pops up:
<img width="422" alt="image" src="https://github.com/user-attachments/assets/9bf66199-c3ea-448e-9b7e-14426267df58" />
It can be caused by doubled slash in url.

<!-- Please mention all relevant issue numbers. -->

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Test the changes locally to ensure they work as expected.
- [ ] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [ ] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [ ] Update documentation to reflect any changes in functionality.
