### PR TITLE
fix: Fix clearing search params

### DIFF
--- a/apps/storefront/src/app/[locale]/(main)/search/actions.ts
+++ b/apps/storefront/src/app/[locale]/(main)/search/actions.ts
@@ -13,18 +13,30 @@ export const handleFiltersFormSubmit = async (
   formData: FormData,
 ) => {
   const formClear = formData.has("clear");
-  const params = new URLSearchParams();
+  const params = new URLSearchParams(searchParams);
   const locale = await getLocale();
 
-  formData.forEach((value, key) => {
-    if (key.startsWith("group")) {
-      const [k, v] = key.replace("group", "").split("-");
+  const filterKeys = new Set<string>();
 
-      params.set(k, params.getAll(k).concat(v).join("."));
-    } else if (value && typeof value === "string" && !formClear) {
-      params.set(key, value);
+  formData.forEach((_, key) => {
+    if (!passThroughParams.includes(key as any)) {
+      filterKeys.add(key);
     }
   });
+
+  if (formClear) {
+    filterKeys.forEach((key) => params.delete(key));
+  } else {
+    formData.forEach((value, key) => {
+      if (key.startsWith("group")) {
+        const [k, v] = key.replace("group", "").split("-");
+
+        params.set(k, params.getAll(k).concat(v).join("."));
+      } else if (value && typeof value === "string") {
+        params.set(key, value);
+      }
+    });
+  }
 
   passThroughParams.forEach((param) => {
     const formValue = formData.get(param) as string;


### PR DESCRIPTION
I want to merge this change because it fixes clearing search params related to navigation. Before, if there were any search params related to navigation (e.g. category) and some related to filters while clearing all of them were cleared, even those not related to filters.

<!-- Please mention all relevant issue numbers. -->

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Test the changes locally to ensure they work as expected.
- [ ] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [ ] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [ ] Update documentation to reflect any changes in functionality.
