### PR TITLE
fix: Fix billing address behaviour when no addresses saved

### DIFF
--- a/apps/storefront/src/app/[locale]/(checkout)/checkout/(checkout-details)/payment/address-tab.tsx
+++ b/apps/storefront/src/app/[locale]/(checkout)/checkout/(checkout-details)/payment/address-tab.tsx
@@ -103,11 +103,13 @@ export function AddressTab({
             countries={countries}
             countryCode={countryCode}
           />
-          <CheckboxField
-            className="pt-6"
-            name="saveAddressForFutureUse"
-            label={t("address.save-address-for-future")}
-          />
+          {hasDefaultBillingAddressSet && (
+            <CheckboxField
+              className="pt-6"
+              name="saveAddressForFutureUse"
+              label={t("address.save-address-for-future")}
+            />
+          )}
         </>
       ) : (
         <Tabs


### PR DESCRIPTION
I want to merge this change because it fixes the issue where an address was being saved as the default billing address, even when the checkbox was not checked and there are no saved addresses yet.

<!-- Please mention all relevant issue numbers. -->

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Test the changes locally to ensure they work as expected.
- [ ] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [ ] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [ ] Update documentation to reflect any changes in functionality.
