### PR TITLE
fix: prevent crash when field.values is undefined

### DIFF
--- a/packages/infrastructure/src/lib/serializers/cms-page.ts
+++ b/packages/infrastructure/src/lib/serializers/cms-page.ts
@@ -17,20 +17,20 @@ export const parseSaleorDataToFields = (
 ): PageField[] => {
   return fields.map((field) => {
     const slug = field.attribute?.slug;
+    const firstValue = field.values?.[0];
+
     const text =
-      getTranslation("plainText", field.values?.[0]) ||
-      field.values?.[0]?.value ||
-      "";
-    const imageUrl = field.values[0].file?.url;
+      getTranslation("plainText", firstValue) || firstValue?.value || "";
+    const imageUrl = firstValue?.file?.url;
     const references = field.values
       ?.map((value) => value.reference)
-      .filter((ref) => ref !== null);
+      .filter((ref): ref is string => ref !== null);
 
     return {
       slug,
       text,
       imageUrl,
-      reference: references.length > 0 ? references : undefined,
+      reference: references?.length ? references : undefined,
     };
   });
 };


### PR DESCRIPTION
I want to merge this change because previously, parseSaleorDataToFields assumed that field.values always contained at least one element.  
This caused a runtime error when field.values was undefined.

This fix ensures safe access to field.values[0] and properly filters the reference array,  
returning undefined instead of an empty array when no references exist.  

As a result, the function is now more robust and prevents potential crashes.

<!-- Please mention all relevant issue numbers. -->

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Test the changes locally to ensure they work as expected.
- [ ] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [ ] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [ ] Update documentation to reflect any changes in functionality.
