### PR TITLE
fix: inconsistent product grid on /search

### DIFF
--- a/apps/storefront/src/app/[locale]/(main)/_components/products-grid.tsx
+++ b/apps/storefront/src/app/[locale]/(main)/_components/products-grid.tsx
@@ -98,7 +98,7 @@ export const ProductsGrid = async ({
           </Button>
         </div>
         {products.map((product) => (
-          <div className="hidden sm:block" key={product.id}>
+          <div className="hidden sm:grid" key={product.id}>
             <SearchProductCard
               product={product}
               sizes="(max-width: 720px) 1vw, (max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"

--- a/apps/storefront/src/components/search-product-card.tsx
+++ b/apps/storefront/src/components/search-product-card.tsx
@@ -12,7 +12,7 @@ import { useLocalizedFormatter } from "@/lib/formatters/use-localized-formatter"
 import { paths } from "@/lib/paths";
 
 export const ProductName = ({ children }: PropsWithChildren) => (
-  <h2 className="line-clamp-2 overflow-hidden text-ellipsis text-left">
+  <h2 className="line-clamp-1 overflow-hidden text-ellipsis text-left">
     {children}
   </h2>
 );
@@ -29,7 +29,7 @@ export const ProductPrice = ({ children }: PropsWithChildren) => {
 
 export const ProductThumbnail = ({ alt, ...props }: ImageProps) => (
   <div className="flex aspect-square justify-center overflow-hidden">
-    <Image alt={alt} className="min-w-full object-contain" {...props} />
+    <Image alt={alt} className="min-w-full object-cover" {...props} />
   </div>
 );
 
@@ -49,7 +49,7 @@ export const SearchProductCard = ({
 
   return (
     <Link
-      className="grid gap-4 rounded-lg bg-white"
+      className="row-span-3 grid grid-rows-subgrid gap-2"
       title={t(`search.go-to-product`, { name })}
       href={paths.products.asPath({
         slug: slug,

--- a/apps/storefront/src/components/search-product-card.tsx
+++ b/apps/storefront/src/components/search-product-card.tsx
@@ -12,7 +12,9 @@ import { useLocalizedFormatter } from "@/lib/formatters/use-localized-formatter"
 import { paths } from "@/lib/paths";
 
 export const ProductName = ({ children }: PropsWithChildren) => (
-  <h2 className="text-left">{children}</h2>
+  <h2 className="line-clamp-2 overflow-hidden text-ellipsis text-left">
+    {children}
+  </h2>
 );
 
 export const ProductPrice = ({ children }: PropsWithChildren) => {
@@ -26,7 +28,7 @@ export const ProductPrice = ({ children }: PropsWithChildren) => {
 };
 
 export const ProductThumbnail = ({ alt, ...props }: ImageProps) => (
-  <div className="flex justify-center">
+  <div className="flex aspect-square justify-center overflow-hidden">
     <Image alt={alt} className="min-w-full object-contain" {...props} />
   </div>
 );


### PR DESCRIPTION
I want to merge this change because it ensures a consistent and visually appealing product grid layout on the /search page by limiting product names to two lines and enforcing a uniform image aspect ratio.

<!-- Please mention all relevant issue numbers. -->

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Test the changes locally to ensure they work as expected.
- [ ] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [ ] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [ ] Update documentation to reflect any changes in functionality.
