### PR TITLE
fix(navigation): prevent unnecessary menu opening for non-dropdown items

### DIFF
--- a/apps/storefront/src/app/[locale]/(main)/_components/navigation.tsx
+++ b/apps/storefront/src/app/[locale]/(main)/_components/navigation.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { useState } from "react";
 
 import type { Menu } from "@nimara/domain/objects/Menu";
@@ -33,34 +34,41 @@ export const Navigation = ({ menu }: { menu: Maybe<Menu> }) => {
       className="mx-auto hidden max-w-screen-xl pb-2 pt-2 md:flex"
     >
       <NavigationMenuList className="gap-6">
-        {menu.items.map((item) => (
-          <NavigationMenuItem key={item.id}>
-            <Link
-              href={item.url}
-              className="text-inherit no-underline hover:underline"
-              legacyBehavior
-              passHref
-            >
-              {!!item.children?.length ? (
-                <NavigationMenuTrigger
-                  showIcon={!!item.children?.length}
-                  onClick={() => setCurrentMenuItem("")}
-                >
-                  {item.label}
-                </NavigationMenuTrigger>
-              ) : (
-                <NavigationMenuLink className={navigationMenuTriggerStyle()}>
-                  {item.label}
-                </NavigationMenuLink>
-              )}
-            </Link>
-            <NavigationMenuContent>
-              <div className="grid w-full grid-cols-6 p-6">
-                <div className="col-span-2 flex flex-col gap-3 pr-6">
-                  {!!item.children?.length &&
-                    item.children
-                      ?.filter((child) => !child.collectionImageUrl)
-                      .map((child) => (
+        {menu.items.map((item) => {
+          const childrenWithoutImage = item.children?.filter(
+            (child) => !child.collectionImageUrl,
+          );
+
+          const childrenWithImage = item.children?.filter(
+            (child) => child.collectionImageUrl,
+          );
+
+          return (
+            <NavigationMenuItem key={item.id}>
+              <Link
+                href={item.url}
+                className="text-inherit no-underline hover:underline"
+                legacyBehavior
+                passHref
+              >
+                {!!item.children?.length ? (
+                  <NavigationMenuTrigger
+                    showIcon={!!item.children?.length}
+                    onClick={() => setCurrentMenuItem("")}
+                  >
+                    {item.label}
+                  </NavigationMenuTrigger>
+                ) : (
+                  <NavigationMenuLink className={navigationMenuTriggerStyle()}>
+                    {item.label}
+                  </NavigationMenuLink>
+                )}
+              </Link>
+              <NavigationMenuContent>
+                <div className="grid w-full grid-cols-6 p-6">
+                  <div className="col-span-2 flex flex-col gap-3 pr-6">
+                    {!!item.children?.length &&
+                      childrenWithoutImage?.map((child) => (
                         <Link
                           key={child.id}
                           href={child.url}
@@ -82,26 +90,27 @@ export const Navigation = ({ menu }: { menu: Maybe<Menu> }) => {
                           </div>
                         </Link>
                       ))}
-                </div>
+                  </div>
 
-                <div className="col-span-4 grid grid-cols-3 gap-3">
-                  {!!item.children?.length &&
-                    item.children
-                      ?.filter((child) => child.collectionImageUrl)
-                      .slice(0, 3)
-                      .map((child) => (
+                  <div className="col-span-4 grid grid-cols-3 gap-3">
+                    {!!item.children?.length &&
+                      childrenWithImage?.slice(0, 3).map((child) => (
                         <Link
                           key={child.id}
                           href={child.url}
                           className="group relative min-h-[270px] overflow-hidden rounded-lg bg-accent"
                           onClick={() => setCurrentMenuItem("")}
                         >
-                          <div
-                            className="h-1/2 bg-cover bg-center"
-                            style={{
-                              backgroundImage: `url(${child?.collectionImageUrl})`,
-                            }}
-                          />
+                          <div className="relative h-1/2">
+                            {child.collectionImageUrl && (
+                              <Image
+                                src={child.collectionImageUrl}
+                                alt={child.label}
+                                layout="fill"
+                                objectFit="cover"
+                              />
+                            )}
+                          </div>
                           <div className="flex h-1/2 flex-col justify-start bg-muted/50 p-6">
                             <div className="relative z-20 space-y-2">
                               <div className="text-lg font-medium leading-none group-hover:underline">
@@ -122,11 +131,12 @@ export const Navigation = ({ menu }: { menu: Maybe<Menu> }) => {
                           </div>
                         </Link>
                       ))}
+                  </div>
                 </div>
-              </div>
-            </NavigationMenuContent>
-          </NavigationMenuItem>
-        ))}
+              </NavigationMenuContent>
+            </NavigationMenuItem>
+          );
+        })}
       </NavigationMenuList>
     </NavigationMenu>
   );

--- a/apps/storefront/src/app/[locale]/(main)/_components/navigation.tsx
+++ b/apps/storefront/src/app/[locale]/(main)/_components/navigation.tsx
@@ -7,8 +7,10 @@ import {
   NavigationMenu,
   NavigationMenuContent,
   NavigationMenuItem,
+  NavigationMenuLink,
   NavigationMenuList,
   NavigationMenuTrigger,
+  navigationMenuTriggerStyle,
 } from "@nimara/ui/components/navigation-menu";
 import { RichText } from "@nimara/ui/components/rich-text";
 
@@ -36,84 +38,93 @@ export const Navigation = ({ menu }: { menu: Maybe<Menu> }) => {
             <Link
               href={item.url}
               className="text-inherit no-underline hover:underline"
+              legacyBehavior
+              passHref
             >
-              <NavigationMenuTrigger showIcon={!!item.children?.length}>
-                {item.label}
-              </NavigationMenuTrigger>
+              {!!item.children?.length ? (
+                <NavigationMenuTrigger
+                  showIcon={!!item.children?.length}
+                  onClick={() => setCurrentMenuItem("")}
+                >
+                  {item.label}
+                </NavigationMenuTrigger>
+              ) : (
+                <NavigationMenuLink className={navigationMenuTriggerStyle()}>
+                  {item.label}
+                </NavigationMenuLink>
+              )}
             </Link>
-            {!!item.children?.length && (
-              <NavigationMenuContent>
-                <div className="grid w-full grid-cols-6 p-6">
-                  <div className="col-span-2 flex flex-col gap-3 pr-6">
-                    {!!item.children?.length &&
-                      item.children
-                        ?.filter((child) => !child.collectionImageUrl)
-                        .map((child) => (
-                          <Link
-                            key={child.id}
-                            href={child.url}
-                            className="group block space-y-1 rounded-md p-3 hover:bg-accent"
-                          >
-                            <div className="text-sm font-medium leading-none">
-                              {child.label}
-                            </div>
-                            <div className="text-sm leading-snug text-muted-foreground">
-                              {child.description &&
-                              isValidJson(child.description) ? (
-                                <RichText
-                                  className="py-1"
-                                  jsonStringData={child.description}
-                                />
-                              ) : (
-                                <p className="py-1">{child.description}</p>
-                              )}
-                            </div>
-                          </Link>
-                        ))}
-                  </div>
+            <NavigationMenuContent>
+              <div className="grid w-full grid-cols-6 p-6">
+                <div className="col-span-2 flex flex-col gap-3 pr-6">
+                  {!!item.children?.length &&
+                    item.children
+                      ?.filter((child) => !child.collectionImageUrl)
+                      .map((child) => (
+                        <Link
+                          key={child.id}
+                          href={child.url}
+                          className="group block space-y-1 rounded-md p-3 hover:bg-accent"
+                        >
+                          <div className="text-sm font-medium leading-none">
+                            {child.label}
+                          </div>
+                          <div className="text-sm leading-snug text-muted-foreground">
+                            {child.description &&
+                            isValidJson(child.description) ? (
+                              <RichText
+                                className="py-1"
+                                jsonStringData={child.description}
+                              />
+                            ) : (
+                              <p className="py-1">{child.description}</p>
+                            )}
+                          </div>
+                        </Link>
+                      ))}
+                </div>
 
-                  <div className="col-span-4 grid grid-cols-3 gap-3">
-                    {!!item.children?.length &&
-                      item.children
-                        ?.filter((child) => child.collectionImageUrl)
-                        .slice(0, 3)
-                        .map((child) => (
-                          <Link
-                            key={child.id}
-                            href={child.url}
-                            className="group relative min-h-[270px] overflow-hidden rounded-lg bg-accent"
-                            onClick={() => setCurrentMenuItem("")}
-                          >
-                            <div
-                              className="h-1/2 bg-cover bg-center"
-                              style={{
-                                backgroundImage: `url(${child?.collectionImageUrl})`,
-                              }}
-                            />
-                            <div className="flex h-1/2 flex-col justify-start bg-muted/50 p-6">
-                              <div className="relative z-20 space-y-2">
-                                <div className="text-lg font-medium leading-none group-hover:underline">
-                                  {child.label}
-                                </div>
-                                <div className="text-sm leading-snug text-muted-foreground">
-                                  {child.description &&
-                                  isValidJson(child.description) ? (
-                                    <RichText
-                                      className="py-1"
-                                      jsonStringData={child.description}
-                                    />
-                                  ) : (
-                                    <p className="py-1">{child.description}</p>
-                                  )}
-                                </div>
+                <div className="col-span-4 grid grid-cols-3 gap-3">
+                  {!!item.children?.length &&
+                    item.children
+                      ?.filter((child) => child.collectionImageUrl)
+                      .slice(0, 3)
+                      .map((child) => (
+                        <Link
+                          key={child.id}
+                          href={child.url}
+                          className="group relative min-h-[270px] overflow-hidden rounded-lg bg-accent"
+                          onClick={() => setCurrentMenuItem("")}
+                        >
+                          <div
+                            className="h-1/2 bg-cover bg-center"
+                            style={{
+                              backgroundImage: `url(${child?.collectionImageUrl})`,
+                            }}
+                          />
+                          <div className="flex h-1/2 flex-col justify-start bg-muted/50 p-6">
+                            <div className="relative z-20 space-y-2">
+                              <div className="text-lg font-medium leading-none group-hover:underline">
+                                {child.label}
+                              </div>
+                              <div className="text-sm leading-snug text-muted-foreground">
+                                {child.description &&
+                                isValidJson(child.description) ? (
+                                  <RichText
+                                    className="py-1"
+                                    jsonStringData={child.description}
+                                  />
+                                ) : (
+                                  <p className="py-1">{child.description}</p>
+                                )}
                               </div>
                             </div>
-                          </Link>
-                        ))}
-                  </div>
+                          </div>
+                        </Link>
+                      ))}
                 </div>
-              </NavigationMenuContent>
-            )}
+              </div>
+            </NavigationMenuContent>
           </NavigationMenuItem>
         ))}
       </NavigationMenuList>


### PR DESCRIPTION
I want to merge this change because it fixes an issue where navbar items without children were incorrectly triggering menu state changes. This update ensures proper behavior by following the recommended approach from the shadcn documentation for handling navigation links.

<!-- Please mention all relevant issue numbers. -->

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Test the changes locally to ensure they work as expected.
- [ ] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [ ] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [ ] Update documentation to reflect any changes in functionality.
