### PR TITLE
fix: Fix locale in sign-in redirection

### DIFF
--- a/apps/storefront/src/app/api/logout/route.ts
+++ b/apps/storefront/src/app/api/logout/route.ts
@@ -1,7 +1,16 @@
 import { type NextRequest, NextResponse } from "next/server";
 
+import { LOCALE_CHANNEL_MAP } from "@/regions/config";
+
 export async function GET(request: NextRequest) {
-  const response = NextResponse.redirect(new URL("/sign-in", request.url));
+  const nextLocale = request.cookies.get("NEXT_LOCALE")?.value;
+
+  const market =
+    LOCALE_CHANNEL_MAP[nextLocale as keyof typeof LOCALE_CHANNEL_MAP] ?? "us";
+
+  const response = NextResponse.redirect(
+    new URL(`/${market}/sign-in`, request.url),
+  );
 
   response.cookies.delete("accessToken");
   response.cookies.delete("refreshToken");


### PR DESCRIPTION
I want to merge this change because it fixes wrong redirection from email change confirmation link to `/sign-in` - now user confirming their email with `gb` locale is being redirected to `/gb/sign-in` page.

<!-- Please mention all relevant issue numbers. -->

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Test the changes locally to ensure they work as expected.
- [ ] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [ ] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [ ] Update documentation to reflect any changes in functionality.
