### PR TITLE
fix(search): allow selecting options on touch devices by removing touched.preventDefault

### DIFF
--- a/apps/storefront/src/app/[locale]/(main)/search/_listing/search-sort-by.tsx
+++ b/apps/storefront/src/app/[locale]/(main)/search/_listing/search-sort-by.tsx
@@ -59,11 +59,7 @@ export const SearchSortBy = ({
           <SelectTrigger className="min-w-40" aria-label={t("search.sort-by")}>
             <SelectValue placeholder={t("search.sort-by")} />
           </SelectTrigger>
-          <SelectContent
-            ref={(ref) =>
-              ref?.addEventListener("touchend", (e) => e.preventDefault())
-            }
-          >
+          <SelectContent>
             <SelectGroup>
               {options.map(({ value, messageKey }) => (
                 <SelectItem value={value} key={value}>


### PR DESCRIPTION
I want to merge this change because the previous touchend.preventDefault listener was preventing option selection on iPads and other touch devices.

<!-- Please mention all relevant issue numbers. -->

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Test the changes locally to ensure they work as expected.
- [ ] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [ ] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [ ] Update documentation to reflect any changes in functionality.
