### PR TITLE
fix(PDP): adjust related products carousel for consistent layout on mobile

### DIFF
--- a/apps/storefront/src/app/[locale]/(main)/products/[slug]/components/related-products.tsx
+++ b/apps/storefront/src/app/[locale]/(main)/products/[slug]/components/related-products.tsx
@@ -26,16 +26,14 @@ export const RelatedProducts = ({
           {products.map((product) => (
             <CarouselItem
               key={product.id}
-              className="w-1/1 h-full flex-none md:w-1/5"
+              className="flex h-auto w-4/5 flex-none flex-col md:w-1/5"
             >
-              <div className="grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-4 md:grid-cols-1">
-                <SearchProductCard
-                  product={product}
-                  sizes="(max-width: 360px) 195px, (max-width: 720px) 379px, 1vw"
-                  height={200}
-                  width={200}
-                />
-              </div>
+              <SearchProductCard
+                product={product}
+                sizes="(max-width: 360px) 195px, (max-width: 720px) 379px, 1vw"
+                height={200}
+                width={200}
+              />
             </CarouselItem>
           ))}
         </CarouselContent>


### PR DESCRIPTION
I want to merge this change because it ensures consistent sizing of product cards in the mobile carousel view. This removes unnecessary wrappers, uses Tailwind utilities correctly (e.g., w-4/5, flex-none), and improves readability and layout stability across breakpoints.

<!-- Please mention all relevant issue numbers. -->

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [x] Test the changes locally to ensure they work as expected.
- [ ] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [ ] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [ ] Update documentation to reflect any changes in functionality.
