### PR TITLE
fix(collection): product thumbnails not displaying when collection has no background image MS-1045

### DIFF
--- a/packages/infrastructure/src/collection/saleor/infrastructure/serialziers.ts
+++ b/packages/infrastructure/src/collection/saleor/infrastructure/serialziers.ts
@@ -24,9 +24,9 @@ export const collectionSerializer = (data: CollectionFragment): Collection => {
         media: null,
         price: node.pricing?.priceRange?.start?.gross.amount ?? 0,
         slug: node.slug,
-        thumbnail: data.backgroundImage?.url
+        thumbnail: node.thumbnail?.url
           ? {
-              url: node.thumbnail?.url ?? "",
+              url: node.thumbnail?.url,
               alt: node.thumbnail?.alt ?? "",
             }
           : null,


### PR DESCRIPTION
I want to merge this change because product thumbnails were incorrectly being set to null if the collection lacked a background image. Now each product correctly uses its own thumbnail regardless of the collection's background image.

<!-- Please mention all relevant issue numbers. -->

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Test the changes locally to ensure they work as expected.
- [ ] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [ ] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [ ] Update documentation to reflect any changes in functionality.
