### PR TITLE
fix(search): clear pagination params on filter change to fix incorrect results

### DIFF
--- a/apps/storefront/src/app/[locale]/(main)/_components/search-pagination.tsx
+++ b/apps/storefront/src/app/[locale]/(main)/_components/search-pagination.tsx
@@ -29,34 +29,6 @@ export const SearchPagination = ({
   const t = useTranslations("common");
   const locale = useLocale();
 
-  // const getPathName = (direction: "next" | "previous") => {
-  //   const params = new URLSearchParams(searchParams);
-
-  //   // Delete all the pagination-related params
-  //   params.delete("before");
-  //   params.delete("after");
-  //   params.delete("page");
-
-  //   if (pageInfo.type === "cursor") {
-  //     console.log(pageInfo.after);
-  //     if (direction === "next") {
-  //       params.set("after", pageInfo.after ?? "");
-  //     } else {
-  //       params.set("before", pageInfo.before ?? "");
-  //     }
-  //   } else {
-  //     const page =
-  //       direction === "next"
-  //         ? pageInfo.currentPage + 1
-  //         : pageInfo.currentPage - 1;
-
-  //     params.set("page", page.toString());
-  //   }
-
-  //   // Shadcn use simple <a> tag instead of next-intl <Link> so we need to pass locale explicitly
-  //   return `${locale !== DEFAULT_LOCALE ? localePrefixes[locale as Exclude<Locale, typeof DEFAULT_LOCALE>] : ""}${baseUrl}?${params.toString()}`;
-  // };
-
   const getPathName = (direction: "next" | "previous") => {
     const params = new URLSearchParams(searchParams);
 

--- a/apps/storefront/src/app/[locale]/(main)/search/actions.ts
+++ b/apps/storefront/src/app/[locale]/(main)/search/actions.ts
@@ -16,6 +16,9 @@ export const handleFiltersFormSubmit = async (
   const params = new URLSearchParams(searchParams);
   const locale = await getLocale();
 
+  params.delete("before");
+  params.delete("after");
+
   const filterKeys = new Set<string>();
 
   formData.forEach((_, key) => {


### PR DESCRIPTION
I want to merge this change because this fixes an issue where changing filters while on a paginated results page would preserve outdated before or after cursors in the URL, leading to incorrect or inconsistent search results. By clearing pagination params (before, after) on every filter change, we ensure that search always starts from the first page with the correct filter context.

<!-- Please mention all relevant issue numbers. -->

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [x] Test the changes locally to ensure they work as expected.
- [ ] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [ ] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [ ] Update documentation to reflect any changes in functionality.
