### PR TITLE
feat: Ensure consistent locale redirect based on previously selected language

### DIFF
--- a/apps/storefront/src/middlewares/i18nMiddleware.test.ts
+++ b/apps/storefront/src/middlewares/i18nMiddleware.test.ts
@@ -30,6 +30,24 @@ describe("i18nMiddleware", () => {
     expect(cookiesHeader).includes(`${COOKIE_KEY.locale}=${DEFAULT_LOCALE};`);
   });
 
+  it("redirects to /gb when visiting root with en-GB locale cookie set", async () => {
+    const initialRequest = new NextRequest(
+      new Request("https://demo.nimara.store/"),
+    );
+
+    initialRequest.cookies.set(COOKIE_KEY.locale, "en-GB");
+    const initialResponse = new NextResponse();
+
+    const resp = await i18nMiddleware(mockNextMiddleware)(
+      initialRequest,
+      mockedFetchEvent,
+      initialResponse,
+    );
+
+    expect(resp?.status).toBe(307);
+    expect(resp?.headers.get("location")).toBe("https://demo.nimara.store/gb");
+  });
+
   it("set the en-GB locale when there's /gb locale prefix in the request", async () => {
     const initialRequest = new NextRequest(
       new Request("https://demo.nimara.store/gb/products/test-product"),

--- a/apps/storefront/src/middlewares/i18nMiddleware.ts
+++ b/apps/storefront/src/middlewares/i18nMiddleware.ts
@@ -119,11 +119,16 @@ export function i18nMiddleware(next: CustomMiddleware): CustomMiddleware {
       maxAge: COOKIE_MAX_AGE.locale,
     });
 
-    const localeFromCookieAgain = request.cookies.get(COOKIE_KEY.locale)?.value;
+    const currentLocaleFromCookie = request.cookies.get(
+      COOKIE_KEY.locale,
+    )?.value;
 
-    if (localeFromCookieAgain && localeFromRequest !== localeFromCookieAgain) {
+    if (
+      currentLocaleFromCookie &&
+      localeFromRequest !== currentLocaleFromCookie
+    ) {
       storefrontLogger.debug(
-        `Locale changed from ${localeFromCookieAgain} to ${localeFromRequest}. Removing the checkoutId cookie.`,
+        `Locale changed from ${currentLocaleFromCookie} to ${localeFromRequest}. Removing the checkoutId cookie.`,
         {
           requestUrl: request.url,
           nextUrl: request.nextUrl.toString(),

--- a/apps/storefront/src/middlewares/i18nMiddleware.ts
+++ b/apps/storefront/src/middlewares/i18nMiddleware.ts
@@ -85,8 +85,8 @@ export function i18nMiddleware(next: CustomMiddleware): CustomMiddleware {
         storefrontLogger.debug(
           `Redirecting root "/" to locale from cookie: ${localeFromCookie} (${localePrefix})`,
         );
-        
-return NextResponse.redirect(new URL(localePrefix, request.url));
+
+        return NextResponse.redirect(new URL(localePrefix, request.url));
       }
     }
 

--- a/apps/storefront/src/middlewares/i18nMiddleware.ts
+++ b/apps/storefront/src/middlewares/i18nMiddleware.ts
@@ -1,6 +1,10 @@
 import { match } from "@formatjs/intl-localematcher";
 import Negotiator from "negotiator";
-import type { NextFetchEvent, NextRequest, NextResponse } from "next/server";
+import {
+  type NextFetchEvent,
+  type NextRequest,
+  NextResponse,
+} from "next/server";
 import createIntlMiddleware from "next-intl/middleware";
 
 import { COOKIE_KEY, COOKIE_MAX_AGE } from "@/config";
@@ -64,6 +68,28 @@ export function i18nMiddleware(next: CustomMiddleware): CustomMiddleware {
     }
 
     const pathname = request.nextUrl.pathname;
+    const localeFromCookie = request.cookies.get(COOKIE_KEY.locale)?.value as
+      | Locale
+      | undefined;
+
+    // Redirect to locale from cookie if visiting root
+    if (
+      pathname === "/" &&
+      localeFromCookie &&
+      SUPPORTED_LOCALES.includes(localeFromCookie) &&
+      localeFromCookie !== DEFAULT_LOCALE
+    ) {
+      const localePrefix = localePrefixes[localeFromCookie];
+
+      if (localePrefix) {
+        storefrontLogger.debug(
+          `Redirecting root "/" to locale from cookie: ${localeFromCookie} (${localePrefix})`,
+        );
+        
+return NextResponse.redirect(new URL(localePrefix, request.url));
+      }
+    }
+
     const localePrefix = Object.values(localePrefixes).find(
       (localePrefix) =>
         pathname.startsWith(localePrefix) || pathname === localePrefix,
@@ -93,11 +119,11 @@ export function i18nMiddleware(next: CustomMiddleware): CustomMiddleware {
       maxAge: COOKIE_MAX_AGE.locale,
     });
 
-    const localeFromCookie = request.cookies.get(COOKIE_KEY.locale)?.value;
+    const localeFromCookieAgain = request.cookies.get(COOKIE_KEY.locale)?.value;
 
-    if (localeFromCookie && localeFromRequest !== localeFromCookie) {
+    if (localeFromCookieAgain && localeFromRequest !== localeFromCookieAgain) {
       storefrontLogger.debug(
-        `Locale changed from ${localeFromCookie} to ${localeFromRequest}. Removing the checkoutId cookie.`,
+        `Locale changed from ${localeFromCookieAgain} to ${localeFromRequest}. Removing the checkoutId cookie.`,
         {
           requestUrl: request.url,
           nextUrl: request.nextUrl.toString(),


### PR DESCRIPTION
I want to merge this change because it ensures consistent locale redirect based on previously selected language from cookie - if user sets gb language, closes browser and opens in with root path, they are being redirected to /gb locale automatically.

<!-- Please mention all relevant issue numbers. -->

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Test the changes locally to ensure they work as expected.
- [ ] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [ ] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [ ] Update documentation to reflect any changes in functionality.
