### PR TITLE
fix(search): avoid using both filter and where in search query

### DIFF
--- a/packages/infrastructure/src/search/saleor/infrastructure/search-infra.ts
+++ b/packages/infrastructure/src/search/saleor/infrastructure/search-infra.ts
@@ -75,17 +75,20 @@ export const saleorSearchInfra =
             after,
             before,
             channel: context.channel,
-            filter: {
-              attributes: attributesFilter,
-              collections: collectionsResult.data,
-              categories: categoriesResult.data,
-            },
+            ...(productIds?.length
+              ? { where: { ids: productIds } }
+              : {
+                  filter: {
+                    attributes: attributesFilter,
+                    collections: collectionsResult.data,
+                    categories: categoriesResult.data,
+                  },
+                }),
             languageCode: context.languageCode as LanguageCodeEnum,
             search: query,
             sortBy: settings.sorting.find(
               (conf) => conf.queryParamValue === sortBy,
             )?.saleorValue,
-            where: productIds ? { ids: productIds } : undefined,
             thumbnailFormat: THUMBNAIL_FORMAT,
             thumbnailSize: THUMBNAIL_SIZE_LARGE,
             ...pageInfo,


### PR DESCRIPTION
I want to merge this change because it fixes a GraphQL error caused by passing both `filter` and `where` arguments to the product search query. With this update, the `where` clause is used exclusively when filtering by product IDs (e.g., for product carousels), and the `filter` object is applied otherwise — preserving support for attributes, categories, and collections filters. This makes the search logic more robust and compatible with Saleor's API constraints.

<!-- Please mention all relevant issue numbers. -->

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Test the changes locally to ensure they work as expected.
- [ ] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [ ] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [ ] Update documentation to reflect any changes in functionality.
