### PR TITLE
fix(form): add error styling to Select component to match other inputs MS-1037

### DIFF
--- a/apps/storefront/src/components/form/select-form-field.tsx
+++ b/apps/storefront/src/components/form/select-form-field.tsx
@@ -42,7 +42,7 @@ export const SelectFormField = ({
       key={name}
       control={control}
       name={name}
-      render={({ field }) => (
+      render={({ field, fieldState }) => (
         <FormItem className="flex-1">
           <FormLabel>
             {label}
@@ -57,7 +57,7 @@ export const SelectFormField = ({
             defaultValue={field.value}
           >
             <FormControl>
-              <SelectTrigger aria-label={label}>
+              <SelectTrigger aria-label={label} error={fieldState.invalid}>
                 <SelectValue placeholder={placeholder} />
               </SelectTrigger>
             </FormControl>

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -15,11 +15,16 @@ const SelectValue = SelectPrimitive.Value;
 const SelectTrigger = ({
   className,
   children,
+  error = false,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Trigger>) => (
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  error?: boolean;
+}) => (
   <SelectPrimitive.Trigger
     className={cn(
       "border-input bg-background ring-offset-background placeholder:text-muted-foreground focus:ring-ring flex h-10 w-full items-center justify-between rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      error &&
+        "border-red-300 bg-red-50 autofill:!bg-red-50 focus-visible:ring-red-300",
       className,
     )}
     {...props}


### PR DESCRIPTION
I want to merge this change because previously the Select field didn't visually indicate validation errors, causing inconsistency with other form inputs. This update introduces consistent error styling and unifies the API with the `Input` component by using the `error` prop.

<!-- Please mention all relevant issue numbers. -->

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [x] Test the changes locally to ensure they work as expected.
- [ ] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [ ] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [ ] Update documentation to reflect any changes in functionality.
