### PR TITLE
fix: prevent running a release job in forked repositories

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   release:
     name: Release
+    if: github.event_name == 'push' && github.event.repository.fork == false
     runs-on: ubuntu-latest
     permissions:
       contents: write # to be able to publish a GitHub release


### PR DESCRIPTION
I want to merge this change because it prevents from triggering a release job when someone will push the main branch in a forked repository.

<!-- Please mention all relevant issue numbers. -->

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Test the changes locally to ensure they work as expected.
- [ ] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [ ] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [ ] Update documentation to reflect any changes in functionality.
