### PR TITLE
perf: replace grid item <img /> with next/image

### DIFF
--- a/packages/features/src/home-page/shared/components/products-grid-client.tsx
+++ b/packages/features/src/home-page/shared/components/products-grid-client.tsx
@@ -12,6 +12,7 @@ import {
   CarouselContent,
   CarouselItem,
 } from "@nimara/ui/components/carousel";
+import Image from "next/image";
 
 type ProductWithPath = SearchProduct & { path: string };
 
@@ -45,14 +46,10 @@ export const ProductsGridClient = ({
   return (
     <>
       <div className="mb-12 grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-4">
-        <div
-          className="relative min-h-44 border-stone-200 bg-cover bg-center p-6"
-          style={{
-            backgroundImage: `url(${image})`,
-          }}
-        >
+        <div className="relative min-h-44 border-stone-200 bg-cover bg-center p-6">
+          <Image className="absolute" alt="" src={image ?? ""} fill />
           <h2
-            className="text-2xl opacity-100"
+            className="relative z-10 text-2xl opacity-100"
             style={{
               color: `${headerFontColor ?? "#44403c"}`,
             }}
@@ -60,7 +57,7 @@ export const ProductsGridClient = ({
             {header}
           </h2>
           <h3
-            className="text-sm"
+            className="relative z-10 text-sm"
             style={{
               color: `${subheaderFontColor ?? "#78716c"}`,
             }}
@@ -68,7 +65,7 @@ export const ProductsGridClient = ({
             {subheader}
           </h3>
           <Button
-            className="absolute right-4 bottom-4 p-3"
+            className="absolute right-4 bottom-4 z-10 p-3"
             variant="outline"
             asChild
             size="icon"

--- a/packages/features/src/home-page/shared/components/products-grid-client.tsx
+++ b/packages/features/src/home-page/shared/components/products-grid-client.tsx
@@ -47,7 +47,12 @@ export const ProductsGridClient = ({
     <>
       <div className="mb-12 grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-4">
         <div className="relative min-h-44 border-stone-200 bg-cover bg-center p-6">
-          <Image className="absolute" alt="" src={image ?? ""} fill />
+          <Image
+            className="absolute object-cover"
+            alt=""
+            src={image ?? ""}
+            fill
+          />
           <h2
             className="relative z-10 text-2xl opacity-100"
             style={{


### PR DESCRIPTION
The current implementation uses a simple `<img />` element, which leads to performance issues caused by downloading the image in full resolution. For example, on dev.nimara.store, the `Homepage grid item image` is over 2.5 MB. It is the largest asset on the homepage, and even on very fast internet connections, it takes a noticeable while to load.

<img width="643" height="197" alt="Screenshot 2026-02-18 at 03 52 17" src="https://github.com/user-attachments/assets/82ba67bc-07d7-45d5-be69-9bf89b2872db" />

Changing the `<img />` to `next/image` will significantly improve performance on slower internet connections. 

<!-- Please mention all relevant issue numbers. -->

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [x] Test the changes locally to ensure they work as expected.
- [x] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [x] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [ ] Update documentation to reflect any changes in functionality.
