### PR TITLE
fix: update vendor page and pdp page

### DIFF
--- a/apps/storefront/src/app/[locale]/(main)/vendor/[vendorSlug]/page.tsx
+++ b/apps/storefront/src/app/[locale]/(main)/vendor/[vendorSlug]/page.tsx
@@ -7,7 +7,7 @@ import type { CMSPage, PageField } from "@nimara/domain/objects/CMSPage";
 import { VendorSearchView } from "@nimara/features/search/shop-basic-plp/vendor-standard";
 import { DEFAULT_LOCALE, LOCALE_PREFIXES } from "@nimara/i18n/config";
 
-import { CACHE_TTL, DEFAULT_RESULTS_PER_PAGE, DEFAULT_SORT_BY } from "@/config";
+import { DEFAULT_RESULTS_PER_PAGE, DEFAULT_SORT_BY } from "@/config";
 import { clientEnvs } from "@/envs/client";
 import { serverEnvs } from "@/envs/server";
 import { getCurrentRegion } from "@/foundation/regions";
@@ -35,75 +35,48 @@ function fieldText(fields: PageField[], slug: string): string | undefined {
 }
 
 /**
- * Unpublished vendor pages are invisible to the anonymous `page` API. Retry with the app token
- * so active vendors are still reachable on the storefront (sign-up creates pages with isPublished: false).
+ * Vendor storefront visibility is gated on two conditions:
+ * 1. `NEXT_PUBLIC_MARKETPLACE_ENABLED=true`
+ * 2. `vendor-status=active`
+ * Saleor publish/draft state has no effect.
  */
-function isVendorVisibleOnStorefront(
-  fields: PageField[],
-  usedElevatedFetch: boolean,
-): boolean {
-  const status = fieldText(fields, VENDOR_STATUS_ATTR)?.toLowerCase();
-
-  if (status === "active") {
-    return true;
-  }
-
-  // Public, published page with no status attribute (legacy).
-  if (!usedElevatedFetch && (status == null || status === "")) {
-    return true;
-  }
-
-  return false;
+function isVendorActive(fields: PageField[]): boolean {
+  return fieldText(fields, VENDOR_STATUS_ATTR)?.toLowerCase() === "active";
 }
 
 const loadVendorProfilePage = cache(
   async (
     vendorSlug: string,
     languageCode: string,
-  ): Promise<{ page: CMSPage | null; usedElevatedFetch: boolean }> => {
+  ): Promise<{ page: CMSPage | null }> => {
     const services = await getServiceRegistry();
     const cmsService = await services.getCMSPageService();
-    const cmsTag = `CMS:${vendorSlug}` as RevalidateTag;
-    const options = {
-      next: {
-        tags: [cmsTag],
-        revalidate: CACHE_TTL.cms,
+
+    /**
+     * Always fetch with the app token (MANAGE_PAGES) so that vendor pages in "draft" state are
+     * still reachable. Publish/draft state is irrelevant — visibility is gated solely on
+     * vendor-status=active in assertValidVendorPage below.
+     */
+    const result = await cmsService.cmsPageGet({
+      slug: vendorSlug,
+      languageCode,
+      options: {
+        cache: "no-store",
       },
-    };
-
-    const publicResult = await cmsService.cmsPageGet({
-      slug: vendorSlug,
-      languageCode,
-      options,
-    });
-
-    if (publicResult.ok && publicResult.data) {
-      return { page: publicResult.data, usedElevatedFetch: false };
-    }
-
-    const staffResult = await cmsService.cmsPageGet({
-      slug: vendorSlug,
-      languageCode,
-      options,
       accessToken: serverEnvs.SALEOR_APP_TOKEN,
     });
 
-    if (staffResult.ok && staffResult.data) {
-      return { page: staffResult.data, usedElevatedFetch: true };
-    }
-
-    return { page: null, usedElevatedFetch: true };
+    return { page: result.ok ? (result.data ?? null) : null };
   },
 );
 
 function assertValidVendorPage(
   page: CMSPage | null,
-  usedElevatedFetch: boolean,
 ): asserts page is CMSPage & { id: string } {
   if (
     !page?.id ||
     page.pageTypeSlug !== VENDOR_PROFILE_PAGE_TYPE_SLUG ||
-    !isVendorVisibleOnStorefront(page.fields, usedElevatedFetch)
+    !isVendorActive(page.fields)
   ) {
     notFound();
   }
@@ -123,12 +96,12 @@ export async function generateMetadata(
 
   const { vendorSlug } = await props.params;
   const region = await getCurrentRegion();
-  const { page, usedElevatedFetch } = await loadVendorProfilePage(
+  const { page } = await loadVendorProfilePage(
     vendorSlug,
     region.language.code,
   );
 
-  assertValidVendorPage(page, usedElevatedFetch);
+  assertValidVendorPage(page);
 
   const displayTitle =
     fieldText(page.fields, VENDOR_PAGE_ATTR_NAME) ?? page.title;
@@ -149,12 +122,12 @@ export default async function Page(props: VendorPageProps) {
     getCurrentRegion(),
   ]);
 
-  const { page, usedElevatedFetch } = await loadVendorProfilePage(
+  const { page } = await loadVendorProfilePage(
     vendorSlug,
     region.language.code,
   );
 
-  assertValidVendorPage(page, usedElevatedFetch);
+  assertValidVendorPage(page);
 
   const displayTitle =
     fieldText(page.fields, VENDOR_PAGE_ATTR_NAME) ?? page.title;

--- a/apps/storefront/src/services/lazy-loaders/store.ts
+++ b/apps/storefront/src/services/lazy-loaders/store.ts
@@ -2,6 +2,7 @@ import type { Logger } from "@nimara/infrastructure/logging/types";
 import type { StoreService } from "@nimara/infrastructure/store/types";
 
 import { clientEnvs } from "@/envs/client";
+import { serverEnvs } from "@/envs/server";
 
 /**
  * Creates a lazy loader function for the store service.
@@ -23,6 +24,7 @@ export const createStoreServiceLoader = (logger: Logger) => {
       apiURI: clientEnvs.NEXT_PUBLIC_SALEOR_API_URL,
       logger,
       marketplaceEnabled: clientEnvs.NEXT_PUBLIC_MARKETPLACE_ENABLED,
+      saleorAppToken: serverEnvs.SALEOR_APP_TOKEN,
     });
 
     return storeServiceInstance;

--- a/packages/features/src/search/shop-basic-plp/vendor-standard.tsx
+++ b/packages/features/src/search/shop-basic-plp/vendor-standard.tsx
@@ -3,9 +3,17 @@ import { getTranslations } from "next-intl/server";
 
 import { ProductsList } from "@nimara/features/shared/product-list/products-list";
 import { SearchPagination } from "@nimara/features/shared/product-list/search-pagination";
+import { LocalizedLink } from "@nimara/i18n/routing";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@nimara/ui/components/breadcrumb";
 import { Skeleton } from "@nimara/ui/components/skeleton";
 
-import { Breadcrumbs } from "../shared/components/breadcrumbs";
 import { FiltersContainer } from "../shared/components/filters/filters-container";
 import { SearchSortBy } from "../shared/components/listing/search-sort-by";
 import { SearchProvider } from "../shared/providers/search-provider";
@@ -116,20 +124,41 @@ export const VendorSearchView = async (props: VendorSearchViewProps) => {
     defaultSortBy,
   } = props;
   const searchParams = await searchParamsPromise;
+  const tHome = await getTranslations("home");
   const headerText = vendorBranding.displayTitle;
 
   return (
-    <SearchProvider
-      searchParams={searchParams}
-      services={services}
-      defaultResultsPerPage={defaultResultsPerPage}
-      defaultSortBy={defaultSortBy}
-      productMetadata={productMetadata}
-      region={region}
-      render={({ products, pageInfo, facets, sortByOptions, searchParams }) => (
-        <div className="w-full">
-          <Breadcrumbs pageName={headerText} homePath={paths.home} />
-          <VendorHero branding={vendorBranding} />
+    <div className="w-full">
+      <div className="hidden md:block">
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink asChild>
+                <LocalizedLink href={paths.home}>{tHome("home")}</LocalizedLink>
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>{headerText}</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+      </div>
+      <VendorHero branding={vendorBranding} />
+      <SearchProvider
+        searchParams={searchParams}
+        services={services}
+        defaultResultsPerPage={defaultResultsPerPage}
+        defaultSortBy={defaultSortBy}
+        productMetadata={productMetadata}
+        region={region}
+        render={({
+          products,
+          pageInfo,
+          facets,
+          sortByOptions,
+          searchParams,
+        }) => (
           <section className="mx-auto my-8 grid gap-8">
             <div className="flex items-center justify-between">
               <h2 className="sr-only">{headerText}</h2>
@@ -167,9 +196,9 @@ export const VendorSearchView = async (props: VendorSearchViewProps) => {
               />
             ) : null}
           </section>
-        </div>
-      )}
-    />
+        )}
+      />
+    </div>
   );
 };
 

--- a/packages/infrastructure/src/cms-page/saleor/graphql/queries/generated.ts
+++ b/packages/infrastructure/src/cms-page/saleor/graphql/queries/generated.ts
@@ -28,6 +28,32 @@ export type PageVariables = Types.Exact<{
 
 export type Page = Page_Query;
 
+export type PagesBySlugs_pages_PageCountableConnection_edges_PageCountableEdge_node_Page_pageType_PageType = { slug: string };
+
+export type PagesBySlugs_pages_PageCountableConnection_edges_PageCountableEdge_node_Page_attributes_SelectedAttribute_attribute_Attribute = { slug: string | null, inputType: Types.AttributeInputTypeEnum | null, name: string | null, translation: Page_page_Page_attributes_SelectedAttribute_attribute_Attribute_translation_AttributeTranslation | null };
+
+export type PagesBySlugs_pages_PageCountableConnection_edges_PageCountableEdge_node_Page_attributes_SelectedAttribute_values_AttributeValue = { slug: string | null, name: string | null, plainText: string | null, richText: string | null, boolean: boolean | null, date: string | null, dateTime: string | null, reference: string | null, value: string | null, translation: Page_page_Page_attributes_SelectedAttribute_values_AttributeValue_translation_AttributeValueTranslation | null, file: Page_page_Page_attributes_SelectedAttribute_values_AttributeValue_file_File | null };
+
+export type PagesBySlugs_pages_PageCountableConnection_edges_PageCountableEdge_node_Page_attributes_SelectedAttribute = { attribute: PagesBySlugs_pages_PageCountableConnection_edges_PageCountableEdge_node_Page_attributes_SelectedAttribute_attribute_Attribute, values: Array<PagesBySlugs_pages_PageCountableConnection_edges_PageCountableEdge_node_Page_attributes_SelectedAttribute_values_AttributeValue> };
+
+export type PagesBySlugs_pages_PageCountableConnection_edges_PageCountableEdge_node_Page = { id: string, slug: string, title: string, content: string | null, pageType: PagesBySlugs_pages_PageCountableConnection_edges_PageCountableEdge_node_Page_pageType_PageType, attributes: Array<PagesBySlugs_pages_PageCountableConnection_edges_PageCountableEdge_node_Page_attributes_SelectedAttribute> };
+
+export type PagesBySlugs_pages_PageCountableConnection_edges_PageCountableEdge = { node: PagesBySlugs_pages_PageCountableConnection_edges_PageCountableEdge_node_Page };
+
+export type PagesBySlugs_pages_PageCountableConnection = { edges: Array<PagesBySlugs_pages_PageCountableConnection_edges_PageCountableEdge> };
+
+export type PagesBySlugs_Query = { pages: PagesBySlugs_pages_PageCountableConnection | null };
+
+
+export type PagesBySlugsVariables = Types.Exact<{
+  first: Types.Scalars['Int']['input'];
+  filter: Types.PageFilterInput;
+  languageCode: Types.LanguageCodeEnum;
+}>;
+
+
+export type PagesBySlugs = PagesBySlugs_Query;
+
 export class TypedDocumentString<TResult, TVariables>
   extends String
   implements DocumentTypeDecoration<TResult, TVariables>
@@ -93,3 +119,54 @@ fragment AttributeValueFragment on AttributeValue {
     url
   }
 }`) as unknown as TypedDocumentString<Page, PageVariables>;
+export const PagesBySlugsDocument = new TypedDocumentString(`
+    query PagesBySlugs($first: Int!, $filter: PageFilterInput!, $languageCode: LanguageCodeEnum!) {
+  pages(first: $first, filter: $filter) {
+    edges {
+      node {
+        id
+        slug
+        pageType {
+          slug
+        }
+        attributes {
+          attribute {
+            ...AttributeFragment
+          }
+          values {
+            ...AttributeValueFragment
+          }
+        }
+        title
+        content
+      }
+    }
+  }
+}
+    fragment AttributeFragment on Attribute {
+  slug
+  inputType
+  name
+  translation(languageCode: $languageCode) {
+    name
+  }
+}
+fragment AttributeValueFragment on AttributeValue {
+  slug
+  name
+  plainText
+  richText
+  boolean
+  date
+  dateTime
+  reference
+  value
+  translation(languageCode: $languageCode) {
+    name
+    plainText
+    richText
+  }
+  file {
+    url
+  }
+}`) as unknown as TypedDocumentString<PagesBySlugs, PagesBySlugsVariables>;

--- a/packages/infrastructure/src/cms-page/saleor/infrastructure/cms-page-get-infra.ts
+++ b/packages/infrastructure/src/cms-page/saleor/infrastructure/cms-page-get-infra.ts
@@ -6,15 +6,32 @@ import { parseSaleorDataToFields } from "#root/lib/serializers/cms-page";
 import type { CMSPageGetInfra } from "#root/use-cases/cms-page/types";
 
 import type { SaleorCMSPageServiceConfig } from "../../types";
-import { PageDocument } from "../graphql/queries/generated";
+import {
+  type Page_page_Page,
+  PageDocument,
+} from "../graphql/queries/generated";
+
+function saleorPageToCMSFields(page: Page_page_Page) {
+  return {
+    id: page.id,
+    pageTypeSlug: page.pageType?.slug ?? null,
+    title: page.title,
+    content: page.content,
+    fields: parseSaleorDataToFields(page.attributes),
+  };
+}
 
 export const saleorCMSPageGetInfra =
   ({ apiURL, logger }: SaleorCMSPageServiceConfig): CMSPageGetInfra =>
   async ({ languageCode, slug, options, accessToken }) => {
+    const fetchOptions = accessToken?.trim()
+      ? { ...options, next: undefined, cache: "no-store" as const }
+      : options;
+
     const result = await graphqlClient(apiURL, accessToken).execute(
       PageDocument,
       {
-        options,
+        options: fetchOptions,
         variables: {
           languageCode: languageCode as LanguageCodeEnum,
           slug,
@@ -26,10 +43,7 @@ export const saleorCMSPageGetInfra =
     if (!result.ok) {
       logger.error(`Error fetching CMS page from Saleor`, {
         error: result.errors,
-        variables: {
-          languageCode,
-          slug,
-        },
+        variables: { languageCode, slug },
       });
 
       return result;
@@ -37,20 +51,11 @@ export const saleorCMSPageGetInfra =
 
     if (!result.data.page) {
       logger.error(`No data returned from Saleor CMS page query`, {
-        variables: {
-          languageCode,
-          slug,
-        },
+        variables: { languageCode, slug },
       });
 
       return ok(null);
     }
 
-    return ok({
-      id: result.data.page.id,
-      pageTypeSlug: result.data.page.pageType?.slug ?? null,
-      title: result.data.page.title,
-      content: result.data.page.content,
-      fields: parseSaleorDataToFields(result.data.page.attributes),
-    });
+    return ok(saleorPageToCMSFields(result.data.page));
   };

--- a/packages/infrastructure/src/lib/serializers/cms-page.ts
+++ b/packages/infrastructure/src/lib/serializers/cms-page.ts
@@ -18,7 +18,10 @@ export const parseSaleorDataToFields = (
     const firstValue = field.values?.[0];
 
     const text =
-      getTranslation("plainText", firstValue) || firstValue?.value || "";
+      getTranslation("plainText", firstValue) ||
+      firstValue?.value ||
+      getTranslation("name", firstValue) ||
+      "";
     const imageUrl = firstValue?.file?.url;
     const references = field.values
       ?.map((value) => value.reference)

--- a/packages/infrastructure/src/store/saleor/graphql/queries/PageSlugById.graphql
+++ b/packages/infrastructure/src/store/saleor/graphql/queries/PageSlugById.graphql
@@ -1,3 +1,5 @@
+#import "../fragments/AttributeValueFragment.graphql"
+
 query PageSlugByIdQuery($id: ID!, $languageCode: LanguageCodeEnum!) {
   page(id: $id) {
     slug
@@ -13,7 +15,7 @@ query PageSlugByIdQuery($id: ID!, $languageCode: LanguageCodeEnum!) {
         slug
       }
       values {
-        name
+        ...AttributeValueFragment
       }
     }
   }

--- a/packages/infrastructure/src/store/saleor/graphql/queries/generated.ts
+++ b/packages/infrastructure/src/store/saleor/graphql/queries/generated.ts
@@ -7,7 +7,11 @@ export type PageSlugByIdQuery_page_Page_pageType_PageType = { slug: string };
 
 export type PageSlugByIdQuery_page_Page_attributes_SelectedAttribute_attribute_Attribute = { slug: string | null };
 
-export type PageSlugByIdQuery_page_Page_attributes_SelectedAttribute_values_AttributeValue = { name: string | null };
+export type PageSlugByIdQuery_page_Page_attributes_SelectedAttribute_values_AttributeValue_translation_AttributeValueTranslation = { name: string, plainText: string | null, richText: string | null };
+
+export type PageSlugByIdQuery_page_Page_attributes_SelectedAttribute_values_AttributeValue_file_File = { url: string };
+
+export type PageSlugByIdQuery_page_Page_attributes_SelectedAttribute_values_AttributeValue = { slug: string | null, name: string | null, plainText: string | null, richText: string | null, boolean: boolean | null, date: string | null, dateTime: string | null, reference: string | null, value: string | null, translation: PageSlugByIdQuery_page_Page_attributes_SelectedAttribute_values_AttributeValue_translation_AttributeValueTranslation | null, file: PageSlugByIdQuery_page_Page_attributes_SelectedAttribute_values_AttributeValue_file_File | null };
 
 export type PageSlugByIdQuery_page_Page_attributes_SelectedAttribute = { attribute: PageSlugByIdQuery_page_Page_attributes_SelectedAttribute_attribute_Attribute, values: Array<PageSlugByIdQuery_page_Page_attributes_SelectedAttribute_values_AttributeValue> };
 
@@ -88,11 +92,7 @@ export type ProductDetailsQuery_product_Product_variants_ProductVariant_selectio
 
 export type ProductDetailsQuery_product_Product_variants_ProductVariant_selectionAttributes_SelectedAttribute_attribute_Attribute = { slug: string | null, inputType: Types.AttributeInputTypeEnum | null, name: string | null, translation: ProductDetailsQuery_product_Product_variants_ProductVariant_selectionAttributes_SelectedAttribute_attribute_Attribute_translation_AttributeTranslation | null };
 
-export type ProductDetailsQuery_product_Product_variants_ProductVariant_selectionAttributes_SelectedAttribute_values_AttributeValue_translation_AttributeValueTranslation = { name: string, plainText: string | null, richText: string | null };
-
-export type ProductDetailsQuery_product_Product_variants_ProductVariant_selectionAttributes_SelectedAttribute_values_AttributeValue_file_File = { url: string };
-
-export type ProductDetailsQuery_product_Product_variants_ProductVariant_selectionAttributes_SelectedAttribute_values_AttributeValue = { slug: string | null, name: string | null, plainText: string | null, richText: string | null, boolean: boolean | null, date: string | null, dateTime: string | null, reference: string | null, value: string | null, translation: ProductDetailsQuery_product_Product_variants_ProductVariant_selectionAttributes_SelectedAttribute_values_AttributeValue_translation_AttributeValueTranslation | null, file: ProductDetailsQuery_product_Product_variants_ProductVariant_selectionAttributes_SelectedAttribute_values_AttributeValue_file_File | null };
+export type ProductDetailsQuery_product_Product_variants_ProductVariant_selectionAttributes_SelectedAttribute_values_AttributeValue = { slug: string | null, name: string | null, plainText: string | null, richText: string | null, boolean: boolean | null, date: string | null, dateTime: string | null, reference: string | null, value: string | null, translation: PageSlugByIdQuery_page_Page_attributes_SelectedAttribute_values_AttributeValue_translation_AttributeValueTranslation | null, file: PageSlugByIdQuery_page_Page_attributes_SelectedAttribute_values_AttributeValue_file_File | null };
 
 export type ProductDetailsQuery_product_Product_variants_ProductVariant_selectionAttributes_SelectedAttribute = { attribute: ProductDetailsQuery_product_Product_variants_ProductVariant_selectionAttributes_SelectedAttribute_attribute_Attribute, values: Array<ProductDetailsQuery_product_Product_variants_ProductVariant_selectionAttributes_SelectedAttribute_values_AttributeValue> };
 
@@ -102,7 +102,7 @@ export type ProductDetailsQuery_product_Product_variants_ProductVariant = { id: 
 
 export type ProductDetailsQuery_product_Product_attributes_SelectedAttribute_attribute_Attribute = { slug: string | null, inputType: Types.AttributeInputTypeEnum | null, name: string | null, translation: ProductDetailsQuery_product_Product_variants_ProductVariant_selectionAttributes_SelectedAttribute_attribute_Attribute_translation_AttributeTranslation | null };
 
-export type ProductDetailsQuery_product_Product_attributes_SelectedAttribute_values_AttributeValue = { slug: string | null, name: string | null, plainText: string | null, richText: string | null, boolean: boolean | null, date: string | null, dateTime: string | null, reference: string | null, value: string | null, translation: ProductDetailsQuery_product_Product_variants_ProductVariant_selectionAttributes_SelectedAttribute_values_AttributeValue_translation_AttributeValueTranslation | null, file: ProductDetailsQuery_product_Product_variants_ProductVariant_selectionAttributes_SelectedAttribute_values_AttributeValue_file_File | null };
+export type ProductDetailsQuery_product_Product_attributes_SelectedAttribute_values_AttributeValue = { slug: string | null, name: string | null, plainText: string | null, richText: string | null, boolean: boolean | null, date: string | null, dateTime: string | null, reference: string | null, value: string | null, translation: PageSlugByIdQuery_page_Page_attributes_SelectedAttribute_values_AttributeValue_translation_AttributeValueTranslation | null, file: PageSlugByIdQuery_page_Page_attributes_SelectedAttribute_values_AttributeValue_file_File | null };
 
 export type ProductDetailsQuery_product_Product_attributes_SelectedAttribute = { attribute: ProductDetailsQuery_product_Product_attributes_SelectedAttribute_attribute_Attribute, values: Array<ProductDetailsQuery_product_Product_attributes_SelectedAttribute_values_AttributeValue> };
 
@@ -220,12 +220,30 @@ export const PageSlugByIdQueryDocument = new TypedDocumentString(`
         slug
       }
       values {
-        name
+        ...AttributeValueFragment
       }
     }
   }
 }
-    `) as unknown as TypedDocumentString<PageSlugByIdQuery, PageSlugByIdQueryVariables>;
+    fragment AttributeValueFragment on AttributeValue {
+  slug
+  name
+  plainText
+  richText
+  boolean
+  date
+  dateTime
+  reference
+  value
+  translation(languageCode: $languageCode) {
+    name
+    plainText
+    richText
+  }
+  file {
+    url
+  }
+}`) as unknown as TypedDocumentString<PageSlugByIdQuery, PageSlugByIdQueryVariables>;
 export const ProductAvailabilityDetailsQueryDocument = new TypedDocumentString(`
     query ProductAvailabilityDetailsQuery($slug: String!, $channel: String!, $countryCode: CountryCode!) {
   product(slug: $slug, channel: $channel) {
@@ -307,7 +325,26 @@ export const ProductDetailsQueryDocument = new TypedDocumentString(`
     ...ProductBaseFragment
   }
 }
-    fragment ProductBaseFragment on Product {
+    fragment AttributeValueFragment on AttributeValue {
+  slug
+  name
+  plainText
+  richText
+  boolean
+  date
+  dateTime
+  reference
+  value
+  translation(languageCode: $languageCode) {
+    name
+    plainText
+    richText
+  }
+  file {
+    url
+  }
+}
+fragment ProductBaseFragment on Product {
   id
   name
   seoTitle
@@ -379,25 +416,6 @@ fragment AttributeFragment on Attribute {
   name
   translation(languageCode: $languageCode) {
     name
-  }
-}
-fragment AttributeValueFragment on AttributeValue {
-  slug
-  name
-  plainText
-  richText
-  boolean
-  date
-  dateTime
-  reference
-  value
-  translation(languageCode: $languageCode) {
-    name
-    plainText
-    richText
-  }
-  file {
-    url
   }
 }`) as unknown as TypedDocumentString<ProductDetailsQuery, ProductDetailsQueryVariables>;
 export const ProductRelatedProductsQueryDocument = new TypedDocumentString(`

--- a/packages/infrastructure/src/store/saleor/infrastructure/get-product-details-infra.ts
+++ b/packages/infrastructure/src/store/saleor/infrastructure/get-product-details-infra.ts
@@ -1,6 +1,7 @@
 import { ok } from "@nimara/domain/objects/Result";
 
 import { graphqlClient } from "#root/graphql/client";
+import { getTranslation } from "#root/lib/saleor";
 import { serializeProduct } from "#root/store/saleor/serializers";
 
 import { IMAGE_FORMAT, IMAGE_SIZES } from "../../config";
@@ -13,13 +14,19 @@ import {
 
 const VENDOR_PROFILE_PAGE_TYPE_SLUG = "vendor-profile";
 const VENDOR_NAME_ATTRIBUTE_SLUG = "vendor-name";
+const VENDOR_STATUS_ATTRIBUTE_SLUG = "vendor-status";
 
 function vendorDisplayNameFromVendorProfilePage(
   page: PageSlugByIdQuery_page_Page,
 ): string | null {
-  const fromAttr = page.attributes
-    .find((a) => a.attribute.slug === VENDOR_NAME_ATTRIBUTE_SLUG)
-    ?.values[0]?.name?.trim();
+  const firstValue = page.attributes.find(
+    (a) => a.attribute.slug === VENDOR_NAME_ATTRIBUTE_SLUG,
+  )?.values[0];
+
+  const fromAttr =
+    getTranslation("plainText", firstValue)?.trim() ||
+    firstValue?.name?.trim() ||
+    firstValue?.value?.trim();
 
   if (fromAttr) {
     return fromAttr;
@@ -34,11 +41,26 @@ function vendorDisplayNameFromVendorProfilePage(
   return page.title.trim() || null;
 }
 
+function vendorStatusIsActive(page: PageSlugByIdQuery_page_Page): boolean {
+  const firstValue = page.attributes.find(
+    (a) => a.attribute.slug === VENDOR_STATUS_ATTRIBUTE_SLUG,
+  )?.values[0];
+
+  const raw =
+    getTranslation("plainText", firstValue)?.trim() ||
+    firstValue?.value?.trim() ||
+    firstValue?.name?.trim() ||
+    "";
+
+  return raw.toLowerCase() === "active";
+}
+
 export const getProductDetailsInfra =
   ({
     apiURI,
     logger,
     marketplaceEnabled = false,
+    saleorAppToken,
   }: StoreServiceConfig): GetProductDetailsInfra =>
   async ({
     productSlug,
@@ -78,26 +100,45 @@ export const getProductDetailsInfra =
     let product = serializeProduct(result.data.product);
 
     if (marketplaceEnabled && product.vendorId) {
-      const slugResult = await graphqlClient(apiURI).execute(
+      const pageVariables = { id: product.vendorId, languageCode };
+
+      let slugResult = await graphqlClient(apiURI).execute(
         PageSlugByIdQueryDocument,
         {
           operationName: "PageSlugByIdQuery",
           options,
-          variables: { id: product.vendorId, languageCode },
+          variables: pageVariables,
         },
       );
 
+      if ((!slugResult.ok || !slugResult.data.page) && saleorAppToken) {
+        const elevatedOptions = {
+          ...options,
+          next: undefined,
+          cache: "no-store" as const,
+        };
+
+        slugResult = await graphqlClient(apiURI, saleorAppToken).execute(
+          PageSlugByIdQueryDocument,
+          {
+            operationName: "PageSlugByIdQuery",
+            options: elevatedOptions,
+            variables: pageVariables,
+          },
+        );
+      }
+
+      const vendorPage = slugResult.ok ? slugResult.data.page : null;
+
       if (
-        slugResult.ok &&
-        slugResult.data.page?.slug &&
-        slugResult.data.page.pageType?.slug === VENDOR_PROFILE_PAGE_TYPE_SLUG
+        vendorPage?.slug &&
+        vendorPage.pageType?.slug === VENDOR_PROFILE_PAGE_TYPE_SLUG &&
+        vendorStatusIsActive(vendorPage)
       ) {
         product = {
           ...product,
-          vendorSlug: slugResult.data.page.slug,
-          vendorName: vendorDisplayNameFromVendorProfilePage(
-            slugResult.data.page,
-          ),
+          vendorSlug: vendorPage.slug,
+          vendorName: vendorDisplayNameFromVendorProfilePage(vendorPage),
         };
       }
     }

--- a/packages/infrastructure/src/store/types.ts
+++ b/packages/infrastructure/src/store/types.ts
@@ -21,6 +21,10 @@ export interface StoreServiceConfig {
    * When true, product details may include `vendorSlug` (extra Saleor query) for vendor storefront URLs.
    */
   marketplaceEnabled?: boolean;
+  /**
+   * Used to resolve vendor profile pages that are not yet published (same as storefront vendor route).
+   */
+  saleorAppToken?: string | null;
 }
 
 export type WithFetchOptions = { options?: FetchOptions };


### PR DESCRIPTION
This PR standardizes vendor handling across the app, with behavior now explicitly gated by `NEXT_PUBLIC_MARKETPLACE_ENABLED`. Vendor data can be read from draft Saleor pages using the app token, but storefront visibility still requires `vendor-status=active`. It also updates related GraphQL/serializer plumbing and includes a small cleanup of the vendor listing UI.

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Test the changes locally to ensure they work as expected.
- [ ] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [ ] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [ ] Update documentation to reflect any changes in functionality.
