### PR TITLE
docs: fix broken Terraform documentation link in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ We welcome all contributions, whether they be code, documentation, bug reports, 
    - Add the original repository as a remote to keep your fork in sync:
 
      ```bash
-     git remote add upstream https://github.com/mirumee/nimara-storefront.git
+     git remote add upstream git@github.com:mirumee/nimara-ecommerce.git
      git fetch upstream
      ```
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ git pull origin main
 
 ## Deploying the app to Vercel using a Terraform
 
-A guide how to deploy the app to Vercel using a Terraform can be found here: [Using Terraform - Nimara Docs](https://docs.nimara.store/quickstart/using-terraform).
+A guide how to deploy the app to Vercel using a Terraform can be found here: [Using Terraform - Nimara Docs](https://docs.nimara.store/docs/quickstart/using-terraform).
 
 ## 📚 Documentation
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ You can also contribute to Nimara in various ways:
 - Share your experiences or projects related to Nimara with the broader community through talks or blog posts.
 - Support [popular feature requests](https://github.com/mirumee/nimara-ecommerce/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) by upvoting them.
 
-For detailed contributing guidelines, please see [Contributing Guide](./docs/CONTRIBUTING.md)
+For detailed contributing guidelines, please see [Contributing Guide](/CONTRIBUTING.md)
 
 ### This wouldn't have been possible without your support
 


### PR DESCRIPTION
I want to merge this change because...
This PR fixes multiple documentation issues found during review:

**File: README.md**
1. Fix broken Terraform documentation link
2. Fix broken Contributing Guide link (was pointing to non-existent docs/CONTRIBUTING.md). Point to `/CONTRIBUTING.md` because the file is in the root directory, not inside `/docs/`.

**File: CONTRIBUTING.md**  
3. Fix incorrect repository URL in upstream setup instructions (was nimara-storefront.git, should be nimara-ecommerce.git)

These are all small, related documentation fixes. I grouped them in one PR to reduce noise, but happy to split if preferred.

**Related issue:**  
Closes #633 


**Changes made:**
- Updated the broken link from `https://docs.nimara.store/quickstart/using-terraform` to `https://docs.nimara.store/docs/quickstart/using-terraform`

**Testing:**
- Verified locally that both links work correctly also on GitHub's preview.


# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [X] Test the changes locally to ensure they work as expected.
- [X] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [ ] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [X] Update documentation to reflect any changes in functionality.
