### PR TITLE
Add LLM wiki, PRD authoring, and epic-definition workflows

### DIFF
--- a/llm-wiki/AGENTS.md
+++ b/llm-wiki/AGENTS.md
@@ -33,15 +33,15 @@ llm-wiki/
   _templates/       # reusable document templates
   sources/          # raw or near-raw source material the notes synthesize
   references/       # source lists and bibliographies
-  product/          # personas, market research, strategy, epics
+  product/          # personas, market research, strategy, PRDs
     personas/
     market/
     strategy/
       initiatives/
-    epics/
-      grilling/     # one durable business-grilling decision log per epic
-    solution/       # created per epic when a technical solution exists
-    tasks/          # created per epic when implementation tasks exist
+    prds/
+      grilling/     # one durable business-grilling decision log per PRD
+    solution/       # created per PRD when a technical solution exists
+    tasks/          # created per PRD when implementation tasks exist
   quality/          # QA operating knowledge
   tech/
     ADR/            # architecture decision records
@@ -92,9 +92,9 @@ Recommended:
 Local extensions currently used:
 
 * `created` - original creation time for the concept.
-* `status`, `owner`, `epic_type`, `template_for` - domain-specific fields on epics,
+* `status`, `owner`, `prd_type`, `template_for` - domain-specific fields on PRDs,
   ADR templates, or other structured notes.
-* `epic_id`, `epic_title`, `session_status` - identity and lifecycle fields on epic
+* `prd_id`, `prd_title`, `session_status` - identity and lifecycle fields on PRD
   grilling logs.
 
 # Links
@@ -162,25 +162,25 @@ Rules:
 * Status lives in frontmatter as `status`.
 * Accepted ADRs are immutable. Supersede them with a new ADR and link both documents.
 * Register every ADR in [ADR MOC](tech/ADR/ADR%20MOC.md) and link it back to the relevant
-  epic, solution, or task note.
+  PRD, solution, or task note.
 
-# Epic Grilling Logs
+# PRD Grilling Logs
 
 Business grilling is preserved as a decision record rather than a raw chat transcript.
 
 Rules:
 
-* Store one log per epic in `product/epics/grilling/` as
-  `EPIC-NNN <Epic Name> - Grilling Log.md`.
-* Create new logs from `_templates/epic-grilling-log.md`. Append later sessions to the same
+* Store one log per PRD in `product/prds/grilling/` as
+  `PRD-NNN <PRD Name> - Grilling Log.md`.
+* Create new logs from `_templates/prd-grilling-log.md`. Append later sessions to the same
   file and continue the `G-*` decision numbering.
 * Record each user-visible question, recommendation, answer, and resulting decision. Include
   rejected metrics or scope, unresolved branches, and decisions deferred to solution design.
 * Summarize rather than expose hidden reasoning. Never copy secrets, personal data, or a
   confidential source body into the log; record only the evidence used and its limitations.
-* Link the epic and grilling log in both directions. Register the log in `index.md` and the
+* Link the PRD and grilling log in both directions. Register the log in `index.md` and the
   creation or update in `log.md`.
-* When an epic is renamed, rename its grilling log and update all inbound links in the same
+* When a PRD is renamed, rename its grilling log and update all inbound links in the same
   change.
 
 # Maintaining The Wiki
@@ -212,7 +212,7 @@ Project wrapper commands:
 ```bash
 pnpm wiki:qmd:setup
 pnpm wiki:qmd:embed
-pnpm wiki:qmd:query "what contradicts the user reviews epic?"
+pnpm wiki:qmd:query "what contradicts the user reviews PRD?"
 pnpm wiki:qmd:search "ADR MOC" -- --json -n 10
 pnpm wiki:qmd:get "#abc123" -- --full
 pnpm wiki:qmd:mcp

--- a/llm-wiki/_templates/ADR.md
+++ b/llm-wiki/_templates/ADR.md
@@ -32,4 +32,4 @@ why the codebase looks the way it does.
 [ADR MOC](tech/ADR/ADR%20MOC.md)
 [DERBY MOC](tech/DERBY/DERBY%20MOC.md)
 Link the DERBY proposal(s) this decision resolves — the accepted design and any rejected alternatives.
-Replace this line with the epic it belongs to, e.g. [Epic Name](product/epics/Epic%20Name.md).
+Replace this line with the PRD it belongs to, e.g. [PRD Name](product/prds/PRD%20Name.md).

--- a/llm-wiki/_templates/prd-grilling-log.md
+++ b/llm-wiki/_templates/prd-grilling-log.md
@@ -1,31 +1,31 @@
 ---
 type: "Template"
-title: "Epic Grilling Log Template"
-description: "Reusable template for recording the business decisions, recommendations, answers, and unresolved branches produced while defining an epic."
+title: "PRD Grilling Log Template"
+description: "Reusable template for recording the business decisions, recommendations, answers, and unresolved branches produced while defining a PRD."
 tags:
   - "template"
-  - "epic"
+  - "prd"
   - "grilling"
   - "decision-log"
 created: "2026-07-10T00:00:00+00:00"
 timestamp: "2026-07-10T00:00:00+00:00"
-template_for: "Epic Grilling Log"
+template_for: "PRD Grilling Log"
 ---
 
-# EPIC-NNN Epic Name — Grilling Log
+# PRD-NNN PRD Name — Grilling Log
 
 ## Purpose
 
-This is a durable record of the user-visible business grilling that shaped the epic. It records questions, recommendations, answers, and decisions; it is not a raw transcript or hidden reasoning trace.
+This is a durable record of the user-visible business grilling that shaped the PRD. It records questions, recommendations, answers, and decisions; it is not a raw transcript or hidden reasoning trace.
 
 ## Session 1 — YYYY-MM-DD
 
 ### Session Context
 
-- Epic: [EPIC-NNN Epic Name](product/epics/EPIC-NNN%20Epic%20Name.md)
-- Trigger: why the epic was created or reopened
+- PRD: [PRD-NNN PRD Name](product/prds/PRD-NNN%20PRD%20Name.md)
+- Trigger: why the PRD was created or reopened
 - Starting evidence: sources used and what they did or did not prove
-- Facilitator: `epic-author`
+- Facilitator: `prd-author`
 - Outcome: `in-progress | stopped | shared-understanding-confirmed | applied`
 
 ### Decision Log
@@ -40,7 +40,7 @@ This is a durable record of the user-visible business grilling that shaped the e
 
 ### Deferred to Solution Design
 
-- Technical question — why it does not belong in the business epic
+- Technical question — why it does not belong in the business PRD
 
 ### Unresolved Branches
 
@@ -50,10 +50,10 @@ This is a durable record of the user-visible business grilling that shaped the e
 
 Summarize the agreed problem, audience, value, evidence, outcomes, falsification, MVP, boundaries, rollout, and ownership.
 
-### Resulting Epic Changes
+### Resulting PRD Changes
 
-- Section or decision changed in the epic
+- Section or decision changed in the PRD
 
 ## Related Notes
 
-[EPIC-NNN Epic Name](product/epics/EPIC-NNN%20Epic%20Name.md)
+[PRD-NNN PRD Name](product/prds/PRD-NNN%20PRD%20Name.md)

--- a/llm-wiki/_templates/prd.md
+++ b/llm-wiki/_templates/prd.md
@@ -1,24 +1,24 @@
 ---
 type: "Template"
-title: "Epic Template"
-description: "Reusable template for drafting OKF-compatible Nimara epic hypothesis statements."
+title: "PRD Template"
+description: "Reusable template for drafting OKF-compatible Nimara Product Requirements Documents."
 tags:
   - "template"
-  - "epic"
+  - "prd"
 created: "2026-07-09T00:00:00+00:00"
 timestamp: "2026-07-09T00:00:00+00:00"
-template_for: "Epic"
+template_for: "Product Requirements Document"
 ---
 
-# Epic Name
+# PRD Name
 
 ## Value Hypothesis
 
-**For** \<persona\> **who** \<need/pain\>, **the** \<epic name\> **is a** \<what it is\> **that** \<key benefit\>, **unlike** \<current alternative\>, **our solution** \<differentiator\>.
+**For** \<persona\> **who** \<need/pain\>, **the** \<product or capability name\> **is a** \<what it is\> **that** \<key benefit\>, **unlike** \<current alternative\>, **our solution** \<differentiator\>.
 
 ## Business Goal & Value
 
-Why this epic exists and what business value it returns. Prose, 1–2 paragraphs.
+Why this PRD exists and what business value it returns. Prose, 1–2 paragraphs.
 
 ## Success Metrics
 
@@ -34,7 +34,7 @@ The smallest slice that tests the hypothesis, and the evidence that would make u
 
 ## Out of Scope
 
-- deferred item — why, and where it goes (fast-follow / separate epic)
+- deferred item — why, and where it goes (fast-follow / separate PRD)
 
 ## User Stories
 

--- a/llm-wiki/index.md
+++ b/llm-wiki/index.md
@@ -8,8 +8,8 @@ okf_version: "0.1"
 # Templates
 * [ADR Template](_templates/ADR.md) - Reusable template for architecture decision records.
 * [DERBY Design Doc Template](_templates/DERBY.md) - Reusable template for a DERBY design proposal: problem, requirements, proposed solution, and cross-cutting considerations.
-* [Epic Grilling Log Template](_templates/epic-grilling-log.md) - Reusable structure for preserving the business decisions behind an epic.
-* [Epic Template](_templates/epic.md) - Reusable template for drafting Nimara epic hypothesis statements.
+* [PRD Grilling Log Template](_templates/prd-grilling-log.md) - Reusable structure for preserving the business decisions behind a PRD.
+* [PRD Template](_templates/prd.md) - Reusable template for drafting Nimara Product Requirements Documents.
 * [Undefined Template](_templates/Undefined.md) - Generic template for a new OKF concept document.
 
 # Sources
@@ -25,13 +25,13 @@ okf_version: "0.1"
 * [Do Not Pursue](product/strategy/Do%20Not%20Pursue.md) - Strategic non-goals and distractions to avoid.
 * [Open Questions & Assumptions](product/strategy/Open%20Questions%20%26%20Assumptions.md) - Assumptions behind the strategy and evidence that could change it.
 
-# Product Epics
-* [Epic Cookie Consent](product/epics/Epic%20Cookie%20Consent.md) - Epic hypothesis for Cookie Consent and Google Consent Mode v2.
-* [EPIC-001 Natural-Language Product Discovery](product/epics/EPIC-001%20Natural-Language%20Product%20Discovery.md) - Analyzing a reusable open-source table-stake capability that keeps Nimara credible for intent-heavy storefront catalogs.
-* [Epic User Reviews](product/epics/Epic%20User%20Reviews.md) - Epic hypothesis for verified-purchase user reviews.
+# Product PRDs
+* [PRD Cookie Consent](product/prds/PRD%20Cookie%20Consent.md) - Product requirements for Cookie Consent and Google Consent Mode v2.
+* [PRD-001 Natural-Language Product Discovery](product/prds/PRD-001%20Natural-Language%20Product%20Discovery.md) - Analyzing a reusable open-source table-stake capability that keeps Nimara credible for intent-heavy storefront catalogs.
+* [PRD User Reviews](product/prds/PRD%20User%20Reviews.md) - Product requirements for verified-purchase user reviews.
 
-# Product Epic Grilling Logs
-* [EPIC-001 Natural-Language Product Discovery - Grilling Log](product/epics/grilling/EPIC-001%20Natural-Language%20Product%20Discovery%20-%20Grilling%20Log.md) - Business questions, recommendations, answers, decisions, and unresolved branches behind EPIC-001.
+# Product PRD Grilling Logs
+* [PRD-001 Natural-Language Product Discovery - Grilling Log](product/prds/grilling/PRD-001%20Natural-Language%20Product%20Discovery%20-%20Grilling%20Log.md) - Business questions, recommendations, answers, decisions, and unresolved branches behind PRD-001.
 
 # Product Market
 * [Composable Commerce Market](product/market/Composable%20Commerce%20Market.md) - Sector maturity and self-hosted open-source economics above the ~$2-10M revenue threshold.

--- a/llm-wiki/log.md
+++ b/llm-wiki/log.md
@@ -1,12 +1,15 @@
 # Directory Update Log
 
+## 2026-07-14
+* **PRD terminology**: Standardized the product-document model as PRD (Product Requirements Document), including `PRD-*` identifiers, `product/prds/` paths, templates, grilling logs, links, and authoring skills.
+
 ## 2026-07-13
 * **Template**: Added [DERBY Design Doc Template](_templates/DERBY.md) — a port of the Mirumee DERBY design page (problem, requirements, proposed solution, cross-cutting considerations). DERBY is a proposal only; the verdict and outcome live in an ADR. Registered it under Templates in `index.md`; kept the Nygard [ADR Template](_templates/ADR.md) separate.
 * **Structure**: Added the `tech/DERBY/` folder and [DERBY MOC](tech/DERBY/DERBY%20MOC.md) as the register for DERBY proposals, mirroring `tech/ADR/`. Cross-linked ADR and DERBY: the [ADR Template](_templates/ADR.md) now names the DERBY it resolves and links both MOCs. Updated the folder tree in `AGENTS.md` and the `index.md` catalogue.
 
 ## 2026-07-10
-* **Grilling log**: Added the decision record and reusable template for [EPIC-001 Natural-Language Product Discovery](product/epics/EPIC-001%20Natural-Language%20Product%20Discovery.md), including the business interview, exclusions, deferred technical branches, and unresolved decisions.
-* **Epic refinement**: Renamed [EPIC-001 Natural-Language Product Discovery](product/epics/EPIC-001%20Natural-Language%20Product%20Discovery.md), promoted it to `analyzing`, and replaced the client-delivery framing with the agreed market-parity hypothesis, validation thresholds, falsification, and MVP boundaries.
+* **Grilling log**: Added the decision record and reusable template for [PRD-001 Natural-Language Product Discovery](product/prds/PRD-001%20Natural-Language%20Product%20Discovery.md), including the business interview, exclusions, deferred technical branches, and unresolved decisions.
+* **PRD refinement**: Renamed [PRD-001 Natural-Language Product Discovery](product/prds/PRD-001%20Natural-Language%20Product%20Discovery.md), promoted it to `analyzing`, and replaced the client-delivery framing with the agreed market-parity hypothesis, validation thresholds, falsification, and MVP boundaries.
 
 ## 2026-07-09
 * **Creation**: Added an OKF placeholder for [3 - UCP-MCP Agentic Discovery](product/strategy/initiatives/3%20-%20UCP-MCP%20Agentic%20Discovery.md), which was referenced by the initiative index.

--- a/llm-wiki/product/personas/Anti-Persona - No-Code Solo Merchant.md
+++ b/llm-wiki/product/personas/Anti-Persona - No-Code Solo Merchant.md
@@ -22,7 +22,7 @@ Nimara is a self-hosted, composable, code-first stack. Serving no-code merchants
 When they ask "how do I install this without a terminal," the answer is a polite pointer to hosted alternatives, not a roadmap item.
 
 ### Note on end shoppers
-End shoppers (buyers) are not an adoption segment — Nimara does not sell to them. They are documented as experience personas ([Shopper](product/personas/Shopper.md) pre-purchase, [Customer](product/personas/Customer.md) post-purchase) because storefront epics need them as a quality bar, but their experience remains the responsibility of the [Storefront Developer](product/personas/Storefront%20Developer.md) and [Ecommerce Manager](product/personas/Ecommerce%20Manager.md) personas. Shopper-facing issues (checkout, search, reviews, channels) should be treated as threats to the developer's trust and the manager's revenue.
+End shoppers (buyers) are not an adoption segment — Nimara does not sell to them. They are documented as experience personas ([Shopper](product/personas/Shopper.md) pre-purchase, [Customer](product/personas/Customer.md) post-purchase) because storefront PRDs need them as a quality bar, but their experience remains the responsibility of the [Storefront Developer](product/personas/Storefront%20Developer.md) and [Ecommerce Manager](product/personas/Ecommerce%20Manager.md) personas. Shopper-facing issues (checkout, search, reviews, channels) should be treated as threats to the developer's trust and the manager's revenue.
 
 ## Related Notes
 [Storefront Developer](product/personas/Storefront%20Developer.md)

--- a/llm-wiki/product/personas/Customer.md
+++ b/llm-wiki/product/personas/Customer.md
@@ -34,7 +34,7 @@ timestamp: "2026-07-08T00:00:00+00:00"
 > "The email asked me to review it — I did, three weeks ago. Where is it?"
 
 ### Product Implications
-- The verified-review loop lives on this persona: invitation timed from fulfillment (configurable delay), a submission window, and fail-alive publishing defaults so feedback never disappears into an unwatched queue (see the User Reviews epic).
+- The verified-review loop lives on this persona: invitation timed from fulfillment (configurable delay), a submission window, and fail-alive publishing defaults so feedback never disappears into an unwatched queue (see the User Reviews PRD).
 - Transactional email is the product surface here — reliable order and fulfillment notifications through the email-provider adapter are the credibility floor.
 - Reliable fulfillment data is a prerequisite: invitation timing and review windows inherit their accuracy from stores marking orders fulfilled (an [Ecommerce Manager](product/personas/Ecommerce%20Manager.md) workflow).
 - GDPR flows (data export, account deletion, review anonymization vs. deletion) must be designed, not improvised — this persona is where those requests come from.

--- a/llm-wiki/product/personas/Shopper.md
+++ b/llm-wiki/product/personas/Shopper.md
@@ -1,7 +1,7 @@
 ---
 type: "Persona"
 title: "Shopper"
-description: "EXPERIENCE persona — the end buyer browsing a Nimara-powered store before purchase. Not a segment Nimara sells to: their experience is the quality bar storefront features are measured against, and the reference point for epics like discovery and reviews."
+description: "EXPERIENCE persona — the end buyer browsing a Nimara-powered store before purchase. Not a segment Nimara sells to: their experience is the quality bar storefront features are measured against, and the reference point for PRDs like discovery and reviews."
 tags:
   - "persona"
   - "experience"
@@ -35,12 +35,12 @@ timestamp: "2026-07-10T00:00:00+00:00"
 
 ### Product Implications
 - Their experience is the [Storefront Developer](product/personas/Storefront%20Developer.md)'s trust and the [Ecommerce Manager](product/personas/Ecommerce%20Manager.md)'s revenue — shopper-facing gaps (performance, search, reviews display, checkout) are defects of the highest order, not enhancements.
-- Social proof is a conversion mechanism: ratings and review counts must be visible on product cards and product pages by default (see the User Reviews epic).
-- Discovery must serve both modes: describing a need in natural language through the reusable [Natural-Language Product Discovery](product/epics/EPIC-001%20Natural-Language%20Product%20Discovery.md) capability and classic search/filter for shoppers who know what they want.
+- Social proof is a conversion mechanism: ratings and review counts must be visible on product cards and product pages by default (see the User Reviews PRD).
+- Discovery must serve both modes: describing a need in natural language through the reusable [Natural-Language Product Discovery](product/prds/PRD-001%20Natural-Language%20Product%20Discovery.md) capability and classic search/filter for shoppers who know what they want.
 - Guest-first flows and mobile performance are defaults, not options — every barrier is measured in silent abandonment.
 
 ## Related Notes
-[EPIC-001 Natural-Language Product Discovery](product/epics/EPIC-001%20Natural-Language%20Product%20Discovery.md)
+[PRD-001 Natural-Language Product Discovery](product/prds/PRD-001%20Natural-Language%20Product%20Discovery.md)
 [Customer](product/personas/Customer.md)
 [Storefront Developer](product/personas/Storefront%20Developer.md)
 [Ecommerce Manager](product/personas/Ecommerce%20Manager.md)

--- a/llm-wiki/product/personas/Storefront Developer.md
+++ b/llm-wiki/product/personas/Storefront Developer.md
@@ -38,7 +38,7 @@ timestamp: "2026-07-10T00:00:00+00:00"
 - Don't hide configuration in UIs; they want env vars, code, and infrastructure-as-code they can read.
 
 ## Related Notes
-[EPIC-001 Natural-Language Product Discovery](product/epics/EPIC-001%20Natural-Language%20Product%20Discovery.md)
+[PRD-001 Natural-Language Product Discovery](product/prds/PRD-001%20Natural-Language%20Product%20Discovery.md)
 [Ecommerce Manager](product/personas/Ecommerce%20Manager.md)
 [Marketplace Vendor](product/personas/Marketplace%20Vendor.md)
 [Anti-Persona - No-Code Solo Merchant](product/personas/Anti-Persona%20-%20No-Code%20Solo%20Merchant.md)

--- a/llm-wiki/product/prds/PRD Cookie Consent.md
+++ b/llm-wiki/product/prds/PRD Cookie Consent.md
@@ -1,9 +1,9 @@
 ---
-type: "Epic"
+type: "Product Requirements Document"
 title: "Cookie Consent & Google Consent Mode v2"
-description: "Epic hypothesis statement for Cookie Consent and Google Consent Mode v2 in the Nimara storefront."
+description: "Product Requirements Document for Cookie Consent and Google Consent Mode v2 in the Nimara storefront."
 tags:
-  - "epic"
+  - "prd"
   - "cookie-consent"
   - "gtm"
   - "compliance"
@@ -11,14 +11,14 @@ created: "2026-07-08T00:00:00+00:00"
 timestamp: "2026-07-08T00:00:00+00:00"
 status: "analyzing"
 owner: "Michał Ociepka"
-epic_type: "Business epic"
+prd_type: "business"
 ---
 
 ## Value Statement
 
 **For** [Ecommerce Manager](product/personas/Ecommerce%20Manager.md) running Nimara stores in consent-regulated markets (EEA/UK)
 **who** must run GTM tracking legally (GDPR/ePrivacy) and keep Google Ads signal alive under Consent Mode v2
-**the** Cookie Consent epic
+**the** Cookie Consent capability
 **is a** built-in consent management layer (banner + Consent Mode v2 wiring) in the Nimara storefront
 **that** blocks tracking until lawful consent, preserves remarketing/measurement via v2 signals, and is configurable per country within channel
 **unlike** SaaS CMPs (Cookiebot, OneTrust, Usercentrics) that cost a subscription per store plus integration work

--- a/llm-wiki/product/prds/PRD User Reviews.md
+++ b/llm-wiki/product/prds/PRD User Reviews.md
@@ -1,9 +1,9 @@
 ---
-type: "Epic"
+type: "Product Requirements Document"
 title: "Verified User Reviews"
-description: "Epic hypothesis statement for a verified-purchase user reviews system in Nimara."
+description: "Product Requirements Document for a verified-purchase user reviews system in Nimara."
 tags:
-  - "epic"
+  - "prd"
   - "reviews"
   - "customer"
   - "conversion"
@@ -11,14 +11,14 @@ created: "2026-07-09T00:00:00+00:00"
 timestamp: "2026-07-09T00:00:00+00:00"
 status: "analyzing"
 owner: "Michał Ociepka"
-epic_type: "Business epic"
+prd_type: "business"
 ---
 
 ## Value Statement
 
 **For** [Customer](product/personas/Customer.md)
 **who** lack the social proof shoppers expect — no ratings on product pages costs conversion, organic visibility, and catalog quality feedback
-**the** Verified User Reviews epic
+**the** Verified User Reviews capability
 **is a** built-in verified-purchase review system
 **that** publishes trustworthy reviews from confirmed buyers
 **unlike** SaaS review services (Yotpo, Judge.me, Trustpilot) that cost a per-store subscription and integration work, or shipping no reviews at all

--- a/llm-wiki/product/prds/PRD-001 Natural-Language Product Discovery.md
+++ b/llm-wiki/product/prds/PRD-001 Natural-Language Product Discovery.md
@@ -1,10 +1,10 @@
 ---
-id: "EPIC-001"
-type: "Epic"
+id: "PRD-001"
+type: "Product Requirements Document"
 title: "Natural-Language Product Discovery"
-description: "Business epic hypothesis for closing Nimara's natural-language discovery gap with a reusable, open-source storefront capability."
+description: "Product Requirements Document for closing Nimara's natural-language discovery gap with a reusable, open-source storefront capability."
 tags:
-  - "epic"
+  - "prd"
   - "product-discovery"
   - "natural-language"
   - "open-source"
@@ -15,7 +15,7 @@ updated: "2026-07-10T00:00:00+00:00"
 timestamp: "2026-07-10T00:00:00+00:00"
 status: "analyzing"
 owner: "Łukasz Szewczyk"
-epic_type: "business"
+prd_type: "business"
 personas:
   - "[Storefront Developer](product/personas/Storefront%20Developer.md)"
   - "[Shopper](product/personas/Shopper.md)"
@@ -25,7 +25,7 @@ personas:
 
 ## Value Hypothesis
 
-**For** [Storefront Developers](product/personas/Storefront%20Developer.md) and agencies evaluating Nimara for storefronts whose catalogs are difficult to navigate with exact keywords **who** may reject Nimara when modern natural-language discovery would otherwise need to be built separately for every project, **the** Natural-Language Product Discovery epic **is a** fully open-source, shopper-facing guided-discovery capability **that** keeps Nimara credible during platform evaluation and lets adopters reach a working, grounded experience within one business day, **unlike** commercial commerce platforms with bundled AI discovery or bespoke integrations rebuilt for each store, **our solution** provides an adopter-owned, opt-in reference experience with one maintained adapter, a swappable provider boundary, catalog validation, classic-search fallback, and reusable documentation.
+**For** [Storefront Developers](product/personas/Storefront%20Developer.md) and agencies evaluating Nimara for storefronts whose catalogs are difficult to navigate with exact keywords **who** may reject Nimara when modern natural-language discovery would otherwise need to be built separately for every project, **the** Natural-Language Product Discovery capability **is a** fully open-source, shopper-facing guided-discovery capability **that** keeps Nimara credible during platform evaluation and lets adopters reach a working, grounded experience within one business day, **unlike** commercial commerce platforms with bundled AI discovery or bespoke integrations rebuilt for each store, **our solution** provides an adopter-owned, opt-in reference experience with one maintained adapter, a swappable provider boundary, catalog validation, classic-search fallback, and reusable documentation.
 
 ## Evidence & Assumptions
 
@@ -37,16 +37,16 @@ personas:
 
 This is a defensive market-parity bet, not a claim that on-site AI discovery is unique. Its purpose is to prevent an increasingly expected capability from disqualifying Nimara before teams can evaluate its genuine advantages: open-source ownership, composability, and replaceable integrations.
 
-The primary business outcome belongs to Nimara: qualified evaluators accept the capability and independent teams deploy it without maintaining a fork. [Shopper](product/personas/Shopper.md) usefulness is the experience quality bar, but store-level conversion, revenue uplift, and catalog-specific relevance targets remain the responsibility of each deployment. No historical adoption baseline is used for this epic.
+The primary business outcome belongs to Nimara: qualified evaluators accept the capability and independent teams deploy it without maintaining a fork. [Shopper](product/personas/Shopper.md) usefulness is the experience quality bar, but store-level conversion, revenue uplift, and catalog-specific relevance targets remain the responsibility of each deployment. No historical adoption baseline is used for this PRD.
 
 ## Success Metrics
 
-- M-1 (business outcome): Qualified-evaluation acceptance — within six months of the public `ready for adoption` release, at least 3 qualified RFPs or solution assessments provide written confirmation that the reference capability satisfies the natural-language discovery requirement — recorded by the epic owner. Silence or absence of an objection does not count.
+- M-1 (business outcome): Qualified-evaluation acceptance — within six months of the public `ready for adoption` release, at least 3 qualified RFPs or solution assessments provide written confirmation that the reference capability satisfies the natural-language discovery requirement — recorded by the PRD owner. Silence or absence of an objection does not count.
 - M-2 (business outcome): Independent adoption — within the same six-month window, at least 2 external teams run a public or customer-facing pilot using their own catalog and provider account without forking the module — confirmed through release feedback or deployment review. Internal demos and multiple storefronts owned by one team count as one proof at most.
 - M-3 (leading indicator): Developer activation — a developer starting with a working Nimara storefront, a discovery-ready catalog, and provider credentials reaches the first grounded result within one business day — measured through the documented onboarding validation.
 - M-4 (quality gate): Catalog validity — 100% of products displayed by the reference experience resolve to products that currently exist and satisfy the deployment's eligibility rules — enforced by the evaluation suite and runtime validation.
 
-GitHub stars, demo traffic, raw query volume, hero clicks, and store-level conversion may be observed diagnostically but do not determine epic success.
+GitHub stars, demo traffic, raw query volume, hero clicks, and store-level conversion may be observed diagnostically but do not determine PRD success.
 
 ## MVP & Falsification
 
@@ -64,7 +64,7 @@ The hypothesis is falsified if at least 3 qualified evaluations occur during the
 - NFR-4: Anonymous shoppers can use the capability without creating an account. Abuse and cost are controlled through configurable limits rather than mandatory authentication.
 - NFR-5: The experience clearly identifies suggestions as AI-assisted and does not present them as objective advice.
 - NFR-6: Raw natural-language queries are not persisted by default. Any deployment that enables raw-query analytics owns its consent, redaction, retention, deletion, and provider-data-transfer policy.
-- NFR-7: Universal latency and cost targets are not set by this epic; every deployment must be able to observe and set its own limits with a safe fallback.
+- NFR-7: Universal latency and cost targets are not set by this PRD; every deployment must be able to observe and set its own limits with a safe fallback.
 
 ## Scope
 
@@ -89,9 +89,9 @@ The hypothesis is falsified if at least 3 qualified evaluations occur during the
 - A core-supported self-hosted model, multiple first-party provider adapters, or validation across multiple commerce engines — future or community work; the MVP maintains one adapter and validates the Saleor reference path.
 - Cart, checkout, or purchasing inside the AI experience — responsibility ends at the standard product page.
 - Ecommerce Manager or merchandiser documentation — deferred until a corresponding operator workflow exists.
-- Recruiting a design partner — explicitly outside the epic; validation relies on future qualified evaluations and independent adopters.
-- Store-level conversion experiments and revenue guarantees — measured by individual deployments, not used as Nimara's epic outcome.
-- Implementation task breakdown, estimates, provider selection, hosting topology, or concrete API signatures — downstream solution design and planning after the epic is accepted.
+- Recruiting a design partner — explicitly outside the PRD; validation relies on future qualified evaluations and independent adopters.
+- Store-level conversion experiments and revenue guarantees — measured by individual deployments, not used as Nimara's PRD outcome.
+- Implementation task breakdown, estimates, provider selection, hosting topology, or concrete API signatures — downstream solution design and planning after the PRD is accepted.
 
 ## User Stories
 
@@ -122,7 +122,7 @@ The hypothesis is falsified if at least 3 qualified evaluations occur during the
 - R-3: Catalog quality varies and may make a valid module appear irrelevant — mitigation: define and validate minimum catalog readiness before counting an adoption attempt; Nimara does not promise to repair merchant content.
 - R-4: Provider cost, latency, or outages may make deployments operationally unattractive — mitigation: adopter-owned accounts, configurable limits, non-blocking behavior, observable usage, and required classic-search fallback.
 - R-5: Queries may contain personal or sensitive information — mitigation: no raw-query persistence by default, explicit data-transfer documentation, and deployment-owned privacy controls for any opt-in analytics.
-- R-6: Customer-specific requests may expand the epic into a search platform, admin product, or conversational assistant — mitigation: enforce the explicit out-of-scope boundaries and require separate evidence for follow-up epics.
+- R-6: Customer-specific requests may expand the PRD into a search platform, admin product, or conversational assistant — mitigation: enforce the explicit out-of-scope boundaries and require separate evidence for follow-up PRDs.
 - R-7: A public demo can create unbounded project cost or abuse exposure — mitigation: use an isolated provider account, a defined operating budget, rate limits, and automatic fallback.
 - R-8: Supporting many providers would create an open-ended maintenance obligation — mitigation: core maintains one reference adapter and a stable extension boundary; additional adapters are future or community work.
 
@@ -135,7 +135,7 @@ The hypothesis is falsified if at least 3 qualified evaluations occur during the
 
 ## Related Notes
 
-[EPIC-001 Natural-Language Product Discovery - Grilling Log](product/epics/grilling/EPIC-001%20Natural-Language%20Product%20Discovery%20-%20Grilling%20Log.md)
+[PRD-001 Natural-Language Product Discovery - Grilling Log](product/prds/grilling/PRD-001%20Natural-Language%20Product%20Discovery%20-%20Grilling%20Log.md)
 [Table Stakes vs Differentiators](product/market/Table%20Stakes%20vs%20Differentiators.md)
 [Product Strategy 2026 (MOC)](product/strategy/Product%20Strategy%202026%20%28MOC%29.md)
 [Top-of-Funnel Adoption Moves](product/strategy/Top-of-Funnel%20Adoption%20Moves.md)

--- a/llm-wiki/product/prds/grilling/PRD-001 Natural-Language Product Discovery - Grilling Log.md
+++ b/llm-wiki/product/prds/grilling/PRD-001 Natural-Language Product Discovery - Grilling Log.md
@@ -1,38 +1,38 @@
 ---
-type: "Epic Grilling Log"
-title: "EPIC-001 Natural-Language Product Discovery - Grilling Log"
-description: "Decision record from the business grilling that reframed EPIC-001 as an open-source market-parity bet for Nimara."
+type: "PRD Grilling Log"
+title: "PRD-001 Natural-Language Product Discovery - Grilling Log"
+description: "Decision record from the business grilling that reframed PRD-001 as an open-source market-parity bet for Nimara."
 tags:
-  - "epic"
+  - "prd"
   - "grilling"
   - "decision-log"
   - "product-discovery"
 created: "2026-07-10T00:00:00+00:00"
 timestamp: "2026-07-10T00:00:00+00:00"
-epic_id: "EPIC-001"
-epic_title: "Natural-Language Product Discovery"
+prd_id: "PRD-001"
+prd_title: "Natural-Language Product Discovery"
 session_status: "applied-with-open-questions"
 ---
 
-# EPIC-001 Natural-Language Product Discovery — Grilling Log
+# PRD-001 Natural-Language Product Discovery — Grilling Log
 
 ## Purpose
 
-This document preserves the user-visible business grilling that shaped [EPIC-001 Natural-Language Product Discovery](product/epics/EPIC-001%20Natural-Language%20Product%20Discovery.md). Questions, recommendations, answers, and resulting decisions are paraphrased for durability. This is not a raw transcript or hidden reasoning trace.
+This document preserves the user-visible business grilling that shaped [PRD-001 Natural-Language Product Discovery](product/prds/PRD-001%20Natural-Language%20Product%20Discovery.md). Questions, recommendations, answers, and resulting decisions are paraphrased for durability. This is not a raw transcript or hidden reasoning trace.
 
 ## Session 1 — 2026-07-10
 
 ### Session Context
 
-- Trigger: The existing LLM Product Discovery epic described delivery for one Polish voucher marketplace instead of development of Nimara as a reusable open-source product.
+- Trigger: The existing LLM Product Discovery PRD described delivery for one Polish voucher marketplace instead of development of Nimara as a reusable open-source product.
 - Starting evidence: one confidential 2026 client requirements document identified AI Search as a `MUST` and a primary UX differentiator. The proposal was lost as a whole; no evidence attributes the loss to this single requirement. The confidential source remains outside the wiki and its body was not copied.
 - Strategic context: [Table Stakes vs Differentiators](product/market/Table%20Stakes%20vs%20Differentiators.md) treats shopper-facing AI recommendations as market parity and UCP/MCP as the separate strategic differentiator.
-- Facilitators: `grilling`, `epic-definition`, and `epic-author` business protocol.
+- Facilitators: `grilling` and the `prd-author` business protocol.
 - Outcome: the user stopped the questions at G-071, accepted the summarized understanding by requesting its application, and then requested this durable log.
 
 ### Discarded Technical Prelude
 
-Two early questions explored a separate discovery service and disabled-by-default registration. The user explicitly redirected the session to business-epic grilling. Those answers are not treated as epic decisions and remain deferred to solution design.
+Two early questions explored a separate discovery service and disabled-by-default registration. The user explicitly redirected the session to business PRD grilling. Those answers are not treated as PRD decisions and remain deferred to solution design.
 
 ### Decision Log
 
@@ -42,16 +42,16 @@ Two early questions explored a separate discovery service and disabled-by-defaul
 | G-002 | Evidence               | Did the missing capability cause the lost proposal?                     | Treat the requirements document as demand evidence, not causal proof.                                                 | Only the requirement and overall proposal loss are known.                       | Record one demand signal and explicitly reject causal attribution.                 |
 | G-003 | Segment                | Which adopters feel the need most strongly?                             | Target developers and agencies building intent-heavy or difficult-to-browse catalogs.                                 | Approved.                                                                       | Primary segment narrowed to technical evaluators of those storefronts.             |
 | G-004 | Value hierarchy        | Which business result is primary?                                       | Make qualified evaluation-to-deployment conversion primary; activation is leading and differentiation is a mechanism. | Approved.                                                                       | Adoption outcome takes precedence over generic differentiation.                    |
-| G-005 | Measurement            | What historical opportunity baseline applies?                           | Use a tracked baseline if available.                                                                                  | Skip the baseline; assume the capability lets Nimara keep pace with the market. | No historical baseline; the epic is a strategic market-parity assumption.          |
-| G-006 | Strategic role         | Is this a differentiator or credibility gap?                            | Reframe as a defensive table stake; UCP/MCP remains the differentiator.                                               | Approved.                                                                       | Epic positioned as market parity, not a unique claim.                              |
+| G-005 | Measurement            | What historical opportunity baseline applies?                           | Use a tracked baseline if available.                                                                                  | Skip the baseline; assume the capability lets Nimara keep pace with the market. | No historical baseline; the PRD is a strategic market-parity assumption.          |
+| G-006 | Strategic role         | Is this a differentiator or credibility gap?                            | Reframe as a defensive table stake; UCP/MCP remains the differentiator.                                               | Approved.                                                                       | PRD positioned as market parity, not a unique claim.                              |
 | G-007 | Business outcomes      | What evidence proves the gap is closed?                                 | Require 3 positive qualified evaluations and 2 independent deployments within 6 months.                               | Approved.                                                                       | These thresholds became the primary validation outcomes.                           |
 | G-008 | Falsification          | What happens when the thresholds are missed?                            | Stop expanding the built-in module and retain an integration seam and guidance.                                       | Approved.                                                                       | Negative evidence triggers a narrow/stop decision.                                 |
 | G-009 | Value boundary         | Is shopper conversion a Nimara success criterion?                       | Keep conversion deployment-specific; use shopper experience as a quality bar.                                         | Approved.                                                                       | Nimara does not claim universal conversion uplift.                                 |
 | G-010 | MVP scope              | Does MVP require an operator moderation dashboard?                      | Exclude it until adoption proves operator demand.                                                                     | Approved.                                                                       | Operator dashboard remains outside MVP.                                            |
-| G-011 | Capability boundary    | Does the epic own all product discovery?                                | Limit it to natural-language discovery; classic search and catalog remain existing dependencies.                      | Natural-language layer only.                                                    | Classic search, filters, and catalog are excluded.                                 |
+| G-011 | Capability boundary    | Does the PRD own all product discovery?                                | Limit it to natural-language discovery; classic search and catalog remain existing dependencies.                      | Natural-language layer only.                                                    | Classic search, filters, and catalog are excluded.                                 |
 | G-012 | Product readiness      | Is documentation alone sufficient?                                      | Require a working reference experience, not only an integration contract.                                             | Approved.                                                                       | Publicly demonstrable capability is part of MVP.                                   |
 | G-013 | Appetite               | What fixed time or team limit applies?                                  | Use a small fixed appetite if it matters to portfolio decisions.                                                      | It does not matter.                                                             | No artificial timebox; keep the smallest credible learning scope.                  |
-| G-014 | Portfolio boundary     | How does this relate to UCP/MCP?                                        | Treat them as independent bets with different consumers and value.                                                    | Approved.                                                                       | Neither epic blocks or subsumes the other.                                         |
+| G-014 | Portfolio boundary     | How does this relate to UCP/MCP?                                        | Treat them as independent bets with different consumers and value.                                                    | Approved.                                                                       | Neither PRD blocks nor subsumes the other.                                        |
 | G-015 | Product promise        | Is provider replaceability business value?                              | Make adopter ownership and lack of lock-in part of the promise; maintain one reference adapter.                       | Approved.                                                                       | Swappability is a business constraint, not multi-provider scope.                   |
 | G-016 | Trust                  | Which failure is unacceptable?                                          | Set zero tolerance for displaying nonexistent or currently ineligible products.                                       | Approved.                                                                       | Catalog validity is a hard gate.                                                   |
 | G-017 | Quality measurement    | Should Nimara set one universal relevance threshold?                    | Initially recommend a human-rated relevance threshold.                                                                | The universal threshold does not matter.                                        | Each deployment sets relevance thresholds; catalog validity stays universal.       |
@@ -66,10 +66,10 @@ Two early questions explored a separate discovery service and disabled-by-defaul
 | G-026 | Adoption proof         | What counts as an independent deployment?                               | External team, own catalog and provider account, customer-facing pilot or production, no fork.                        | Approved.                                                                       | Internal demos and duplicate storefronts do not inflate the count.                 |
 | G-027 | Evaluation proof       | What counts as passing an RFP or assessment?                            | Require written positive confirmation; silence does not count.                                                        | Approved.                                                                       | Qualified evaluation acceptance is explicit evidence.                              |
 | G-028 | Validation window      | When does the six-month clock start?                                    | Start at public `ready for adoption`, not preview.                                                                    | Approved.                                                                       | Preview does not consume validation time.                                          |
-| G-029 | Governance             | Who owns evidence collection and the stop decision?                     | Assign the epic owner; the session named Michał Ociepka.                                                              | Approved in session.                                                            | Current epic frontmatter names Łukasz Szewczyk; ownership discrepancy remains U-2. |
-| G-030 | Priority               | Where does this sit relative to Zero-to-Deploy?                         | `Next`, after the foundational adoption path.                                                                         | Approved.                                                                       | Epic must not displace Zero-to-Deploy.                                             |
+| G-029 | Governance             | Who owns evidence collection and the stop decision?                     | Assign the PRD owner; the session named Michał Ociepka.                                                              | Approved in session.                                                            | Current PRD frontmatter names Łukasz Szewczyk; ownership discrepancy remains U-2. |
+| G-030 | Priority               | Where does this sit relative to Zero-to-Deploy?                         | `Next`, after the foundational adoption path.                                                                         | Approved.                                                                       | PRD must not displace Zero-to-Deploy.                                             |
 | G-031 | Naming                 | Should the name remain implementation-led?                              | Rename to Natural-Language Product Discovery.                                                                         | Approved.                                                                       | Name now survives provider or implementation changes.                              |
-| G-032 | Classification         | Is this a business or enabler epic?                                     | Keep `business`; technical work is a means to adoption.                                                               | Approved.                                                                       | Epic type remains business.                                                        |
+| G-032 | Classification         | Is this a business or enabler PRD?                                     | Keep `business`; technical work is a means to adoption.                                                               | Approved.                                                                       | PRD type remains business.                                                        |
 | G-033 | Metrics                | Do stars, demo traffic, query volume, or hero clicks determine success? | Treat them as diagnostics, not outcomes.                                                                              | Approved.                                                                       | Vanity metrics do not determine continue/stop.                                     |
 | G-034 | Catalog responsibility | Must Nimara work regardless of catalog quality?                         | Define readiness and expose missing data; do not promise content repair.                                              | Approved.                                                                       | Unready catalogs do not count as valid adoption tests.                             |
 | G-035 | Performance            | May the module degrade the base storefront?                             | Disabled means no impact; enabled remains non-blocking with fallback.                                                 | Approved.                                                                       | Storefront performance and classic search are protected.                           |
@@ -91,8 +91,8 @@ Two early questions explored a separate discovery service and disabled-by-defaul
 | G-051 | Evidence integrity     | Is adoption impact a fact or assumption?                                | Label it `[ASSUMPTION]`.                                                                                              | Approved.                                                                       | One RFP and market evidence do not prove adoption uplift.                          |
 | G-052 | Primary persona        | Create a new procurement persona or use Storefront Developer?           | Use Storefront Developer, including agency evaluators.                                                                | Approved.                                                                       | Existing primary persona is retained and narrowed by segment.                      |
 | G-053 | Shopper role           | Is Shopper the business buyer?                                          | Treat Shopper as the experience quality persona.                                                                      | Approved.                                                                       | Business success belongs to adopter evaluation and deployment.                     |
-| G-054 | Lifecycle              | What status follows applied grilling decisions?                         | Move from `draft` to `analyzing`.                                                                                     | Approved.                                                                       | Epic status is `analyzing`.                                                        |
-| G-055 | Operating thresholds   | Does the epic set universal latency and cost limits?                    | Let deployments set them; require visibility, limits, and fallback.                                                   | Approved.                                                                       | No universal latency or unit-cost target.                                          |
+| G-054 | Lifecycle              | What status follows applied grilling decisions?                         | Move from `draft` to `analyzing`.                                                                                     | Approved.                                                                       | PRD status is `analyzing`.                                                        |
+| G-055 | Operating thresholds   | Does the PRD set universal latency and cost limits?                    | Let deployments set them; require visibility, limits, and fallback.                                                   | Approved.                                                                       | No universal latency or unit-cost target.                                          |
 | G-056 | Segment threshold      | Is a minimum catalog size required?                                     | Describe complexity qualitatively rather than by SKU count.                                                           | Approved.                                                                       | No numeric catalog-size gate.                                                      |
 | G-057 | UI ownership           | Does reference UI dictate layout and branding?                          | Demonstrate a complete accessible flow but allow composition and theming.                                             | Approved.                                                                       | Client-specific hero and cards are not core.                                       |
 | G-058 | Result count           | Is 3–5 suggestions a universal business rule?                           | Use it only as a configurable demo default.                                                                           | Approved.                                                                       | Shortlist length is deployment-configurable.                                       |
@@ -108,13 +108,13 @@ Two early questions explored a separate discovery service and disabled-by-defaul
 | G-068 | Demand insight         | Is unmatched-query analysis part of the value hypothesis?               | Report aggregate no-match only; defer content analytics and workflows.                                                | Approved.                                                                       | Demand insights removed from MVP value.                                            |
 | G-069 | Commerce engines       | Must MVP prove multiple backends?                                       | Validate Saleor without store-specific assumptions.                                                                   | Approved.                                                                       | Additional commerce-engine validation is future work.                              |
 | G-070 | Demo catalog           | Can the confidential voucher catalog shape the public demo?             | Use a neutral, public, intent-rich Nimara catalog.                                                                    | Approved.                                                                       | Demo does not imply a gift-market vertical or reuse confidential content.          |
-| G-071 | Falsification nuance   | What if too few RFPs or adoption attempts occur in six months?          | Treat it as insufficient evidence and freeze expansion without claiming a negative result.                            | User ended the questions.                                                       | Unresolved as U-1 and preserved in the epic Open Questions.                        |
+| G-071 | Falsification nuance   | What if too few RFPs or adoption attempts occur in six months?          | Treat it as insufficient evidence and freeze expansion without claiming a negative result.                            | User ended the questions.                                                       | Unresolved as U-1 and preserved in the PRD Open Questions.                        |
 
 ### Rejected or Deliberately Excluded
 
 - Historical adoption baseline — explicitly skipped in favor of a forward-looking market-parity validation.
-- Universal relevance, latency, cost, and catalog-size targets — delegated to deployments or explicitly judged irrelevant at epic level.
-- Store-level conversion, revenue uplift, GitHub stars, traffic, raw query volume, and hero clicks — diagnostic only, not epic success criteria.
+- Universal relevance, latency, cost, and catalog-size targets — delegated to deployments or explicitly judged irrelevant at PRD level.
+- Store-level conversion, revenue uplift, GitHub stars, traffic, raw query volume, and hero clicks — diagnostic only, not PRD success criteria.
 - Operator dashboard, demand insights, multi-turn conversation, required `show more`, direct feedback, personalization, voice, SEO output, conversational checkout, and design-partner recruitment — outside MVP.
 - Client-specific assumptions from the voucher marketplace — not part of Nimara core or the public demo.
 
@@ -128,31 +128,31 @@ Two early questions explored a separate discovery service and disabled-by-defaul
 ### Unresolved Branches
 
 - U-1: If too few qualified evaluations or adoption attempts occur during the six-month window, decide whether the result is inconclusive with investment frozen or receives the same stop decision as negative evidence — Product — before `ready`.
-- U-2: The grilling session approved Michał Ociepka as outcome owner, while the applied epic frontmatter names Łukasz Szewczyk — Product — reconcile before `ready`.
+- U-2: The grilling session approved Michał Ociepka as outcome owner, while the applied PRD frontmatter names Łukasz Szewczyk — Product — reconcile before `ready`.
 - U-3: Set the public-demo operating budget — Product — before preview.
 - U-4: Choose the core-maintained reference adapter — Architecture — before solution design approval.
 - U-5: Define minimum discovery-ready catalog content and eligibility semantics — Product and Architecture — before solution design approval.
 
 ### Shared Understanding
 
-Natural-Language Product Discovery is a `Next`-priority business epic that closes a market-parity gap for developers and agencies evaluating Nimara for intent-heavy catalogs. The evidence proves one real requirement and wider market movement, not that the missing feature caused a lost proposal. The adoption effect remains an explicit assumption.
+Natural-Language Product Discovery is a `Next`-priority business PRD that closes a market-parity gap for developers and agencies evaluating Nimara for intent-heavy catalogs. The evidence proves one real requirement and wider market movement, not that the missing feature caused a lost proposal. The adoption effect remains an explicit assumption.
 
 Success means 3 positive written qualified evaluations and 2 independent customer-facing deployments without a fork within 6 months of the public ready release; a developer should reach the first grounded result within one business day. Shopper conversion is deployment-specific. The universal quality gate is zero displayed products that do not exist or fail current eligibility.
 
 MVP is fully open-source, opt-in, single-turn, prominent in the public demo, provider-replaceable with one maintained adapter, anonymous-first, locale-aware, accessible, non-blocking, rate-limited, privacy-conscious, and backed by classic-search fallback. It ends at the product page. UCP/MCP, full classic discovery, operator tooling, personalization, demand insights, SEO, self-hosted support, multi-engine validation, cart, and checkout remain separate.
 
-### Resulting Epic Changes
+### Resulting PRD Changes
 
-- Renamed the epic from LLM Product Discovery to Natural-Language Product Discovery.
+- Renamed the PRD from LLM Product Discovery to Natural-Language Product Discovery.
 - Replaced client-delivery framing with an open-source market-parity hypothesis.
 - Added evidence limitations and the adoption `[ASSUMPTION]`.
 - Added quantified evaluation, deployment, activation, and catalog-validity measures.
 - Added negative falsification, rollout, business NFRs, MVP boundaries, risks, and open questions.
-- Moved the epic to `analyzing` after explicit user approval.
+- Moved the PRD to `analyzing` after explicit user approval.
 
 ## Related Notes
 
-[EPIC-001 Natural-Language Product Discovery](product/epics/EPIC-001%20Natural-Language%20Product%20Discovery.md)
+[PRD-001 Natural-Language Product Discovery](product/prds/PRD-001%20Natural-Language%20Product%20Discovery.md)
 [Table Stakes vs Differentiators](product/market/Table%20Stakes%20vs%20Differentiators.md)
 [Storefront Developer](product/personas/Storefront%20Developer.md)
 [Shopper](product/personas/Shopper.md)

--- a/llm-wiki/product/strategy/Product Strategy 2026 (MOC).md
+++ b/llm-wiki/product/strategy/Product Strategy 2026 (MOC).md
@@ -28,7 +28,7 @@ The core recommendation: prioritize an automated **"Zero-to-Deploy" setup CLI** 
 - [Emerging Trends 2026](product/market/Emerging%20Trends%202026.md) — agentic commerce, UCP/MCP, marketplaces, deploy-in-minutes DX
 - [Developer Pain Points](product/market/Developer%20Pain%20Points.md) — community feedback and competitor stability/security gaps
 
-### Prioritized roadmap (seed for epics)
+### Prioritized roadmap (seed for PRDs)
 - [Initiative Prioritization](product/strategy/initiatives/Initiative%20Prioritization.md) — the ranked scoring table
   1. [1 - Zero-to-Deploy CLI](product/strategy/initiatives/1%20-%20Zero-to-Deploy%20CLI.md) — *Now*
   2. [2 - Stripe Connect Split Payments](product/strategy/initiatives/2%20-%20Stripe%20Connect%20Split%20Payments.md) — *Now*

--- a/llm-wiki/product/strategy/initiatives/Initiative Prioritization.md
+++ b/llm-wiki/product/strategy/initiatives/Initiative Prioritization.md
@@ -23,10 +23,10 @@ Scores are 1–5 (higher = stronger), except Effort/Risk where higher = more eff
 | [4 - Auto-Invoicing & Regional Tax](product/strategy/initiatives/4%20-%20Auto-Invoicing%20%26%20Regional%20Tax.md) | [Ecommerce Manager](product/personas/Ecommerce%20Manager.md) | 3 | 3 | 4 | 2 (Low) | **Next** |
 | [5 - Provider-Agnostic Interface](product/strategy/initiatives/5%20-%20Provider-Agnostic%20Interface.md) | [Storefront Developer](product/personas/Storefront%20Developer.md) | 3 | 4 | 3 | 4 (High) | **Later** |
 
-### How to use this for epics
-- Each row links to a full initiative note containing Outcome, rationale, success criteria, in/out of scope, and risks — ready to seed an epic.
+### How to use this for PRDs
+- Each row links to a full initiative note containing Outcome, rationale, success criteria, in/out of scope, and risks — ready to seed a PRD.
 - "Now" tier = the two bets to staff immediately; "Next"/"Later" = sequence behind them.
-- Pair this with the epic template conventions when drafting epics.
+- Pair this with the PRD template conventions when drafting PRDs.
 
 ## Related Notes
 [1 - Zero-to-Deploy CLI](product/strategy/initiatives/1%20-%20Zero-to-Deploy%20CLI.md)

--- a/llm-wiki/product/tasks/llm-product-discovery.json
+++ b/llm-wiki/product/tasks/llm-product-discovery.json
@@ -1,9 +1,9 @@
 {
   "document": "Developer Task Breakdown",
-  "epic": {
+  "prd": {
     "name": "LLM Product Discovery",
     "projectKeyPlaceholder": "LPD",
-    "epicSummary": "AI-powered natural-language product discovery with classic search fallback — Saleor Cloud + Next.js/Vercel + AWS (eu-central-1)",
+    "prdSummary": "AI-powered natural-language product discovery with classic search fallback — Saleor Cloud + Next.js/Vercel + AWS (eu-central-1)",
     "reference": "technical-solution-llm-product-discovery.json v1.0"
   },
   "conventions": {

--- a/llm-wiki/quality/Quality & Testing (MOC).md
+++ b/llm-wiki/quality/Quality & Testing (MOC).md
@@ -17,7 +17,7 @@ timestamp: "2026-06-30T00:00:00+00:00"
 ### What this section is for
 This is the QA brain for **agents working on Nimara**. Read it before touching a test or a Jira ticket so you don't rediscover the environment, the board mechanics, or the verdict rules the hard way. Knowledge lives in these notes; the executable runbooks live as skills under `skills/qa/`.
 
-> Pairing convention (same as the rest of this wiki): notes = read-context, **skills = runbooks** that cite them. The QA skills read these notes the way `epic-definition` reads `[Storefront Developer](product/personas/Storefront%20Developer.md)`.
+> Pairing convention (same as the rest of this wiki): notes = read-context, **skills = runbooks** that cite them. The QA skills read these notes the way `prd-author` reads `[Storefront Developer](product/personas/Storefront%20Developer.md)`.
 
 ### Read-me-first (the 80%)
 1. [Environments & Access Matrix](quality/Environments%20%26%20Access%20Matrix.md) — which env, which channel, what you can/can't reach. **Biggest source of wasted effort if skipped.**

--- a/scripts/wiki-qmd.mjs
+++ b/scripts/wiki-qmd.mjs
@@ -5,12 +5,15 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
 const wikiDir = path.join(repoRoot, "llm-wiki");
 const collectionName = "nimara-wiki";
 const indexName = process.env.QMD_INDEX || "nimara-wiki";
 const context =
-  "Nimara LLM wiki: product strategy, QA process, ADRs, epics, source notes. Use llm-wiki/sources/LLM Wiki.md for the pattern and llm-wiki/AGENTS.md for the local schema.";
+  "Nimara LLM wiki: product strategy, QA process, ADRs, PRDs, source notes. Use llm-wiki/sources/LLM Wiki.md for the pattern and llm-wiki/AGENTS.md for the local schema.";
 
 const command = process.argv[2] || "help";
 const rest = process.argv.slice(3).filter((arg) => arg !== "--");
@@ -93,7 +96,15 @@ function setup() {
   if (hasCollection()) {
     console.log(`qmd collection already configured: ${collectionName}`);
   } else {
-    run(["collection", "add", wikiDir, "--name", collectionName, "--mask", "**/*.md"]);
+    run([
+      "collection",
+      "add",
+      wikiDir,
+      "--name",
+      collectionName,
+      "--mask",
+      "**/*.md",
+    ]);
   }
 
   if (hasContext()) {
@@ -103,7 +114,9 @@ function setup() {
   }
 
   run(["status"]);
-  console.log("\nNext: run `pnpm wiki:qmd:embed` to generate vector embeddings.");
+  console.log(
+    "\nNext: run `pnpm wiki:qmd:embed` to generate vector embeddings.",
+  );
 }
 
 function withCollection(args) {
@@ -140,7 +153,10 @@ switch (command) {
     run(withCollection(["search", ...rest]));
     break;
   case "query":
-    requireArgs(rest, 'pnpm wiki:qmd:query "what contradicts the reviews epic?"');
+    requireArgs(
+      rest,
+      'pnpm wiki:qmd:query "what contradicts the reviews PRD?"',
+    );
     run(withCollection(["query", ...rest]));
     break;
   case "get":

--- a/skills/llm-wiki/SKILL.md
+++ b/skills/llm-wiki/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: llm-wiki
-description: Work with llm-wiki knowledge base using QMD-backed retrieval and source-file verification. Use when answering questions from llm-wiki, finding relevant notes, auditing wiki consistency, ingesting or filing durable knowledge back into llm-wiki, updating wiki conventions, or helping agents use the llm-wiki/sources/LLM Wiki.md pattern. Use for product strategy, QA process, ADR, persona, epic, source, and wiki-maintenance questions that should cite or update llm-wiki.
+description: Work with llm-wiki knowledge base using QMD-backed retrieval and source-file verification. Use when answering questions from llm-wiki, finding relevant notes, auditing wiki consistency, ingesting or filing durable knowledge back into llm-wiki, updating wiki conventions, or helping agents use the llm-wiki/sources/LLM Wiki.md pattern. Use for product strategy, QA process, ADR, persona, PRD, source, and wiki-maintenance questions that should cite or update llm-wiki.
 ---
 
 # LLM Wiki
@@ -84,7 +84,7 @@ For lint, ingest, ADR, or answer-and-file-back work, also read `skills/wiki/wiki
 ## Useful Probes
 
 ```bash
-pnpm wiki:qmd:query "what contradicts the user reviews epic?" -- --json --no-rerank -n 10
+pnpm wiki:qmd:query "what contradicts the user reviews PRD?" -- --json --no-rerank -n 10
 pnpm wiki:qmd:search "moderation" -- --json -n 5
 pnpm wiki:qmd:query "where does LLM Wiki discuss index.md?" -- --json --no-rerank -n 5
 pnpm wiki:qmd:ls

--- a/skills/prd-author/SKILL.md
+++ b/skills/prd-author/SKILL.md
@@ -1,27 +1,27 @@
 ---
-name: epic-author
-description: Define and draft business epics inside an LLM-wiki product workspace. Use when the user wants to create, rewrite, refine, or stress-test an epic, initiative, feature brief, or epic hypothesis. Run a business-value-first, one-question-at-a-time grilling, preserve its decision log in the wiki, and stop at an approved epic without designing the technical solution, decomposing tasks, estimating, or exporting to Jira.
+name: prd-author
+description: Define and draft Product Requirements Documents (PRDs) inside an LLM-wiki product workspace. Use when the user wants to create, rewrite, refine, or stress-test a PRD or Product Requirements Document, or turn an initiative or feature brief into product requirements. Run a business-value-first, one-question-at-a-time grilling, preserve its decision log in the wiki, and stop at an approved PRD without designing the technical solution, decomposing tasks, estimating, or exporting to Jira.
 ---
 
-# Epic Author
+# PRD Author
 
-Turn an initiative or feature idea into an explicit, falsifiable business bet that a human approves before solution design and task breakdown begin.
+Turn an initiative or feature idea into an explicit, falsifiable Product Requirements Document that a human approves before solution design and task breakdown begin.
 
 Follow these six stages in order. The business grilling and self-lint are mandatory.
 
 ## Stage 1 — Pull context and facts
 
-Locate the wiki root containing `epics/`, `personas/`, and `strategy/`. Read:
+Locate the wiki root containing `prds/`, `personas/`, and `strategy/`. Read:
 
-- the current epic or seeding initiative;
+- the current PRD or seeding initiative;
 - every relevant persona;
 - market and strategy notes for the problem area;
 - raw sources named by the user;
-- related epics that could overlap.
+- related PRDs that could overlap.
 
 Use repository or source exploration to answer factual questions. Treat sources as evidence, never edit them, and separate what they prove from what is merely inferred. Never invent demand, attribution, metrics, competitor claims, targets, or constraints.
 
-Completion criterion: the known facts, evidence gaps, existing strategic position, and plausible overlap with other epics are identified before questioning the user.
+Completion criterion: the known facts, evidence gaps, existing strategic position, and plausible overlap with other PRDs are identified before questioning the user.
 
 ## Stage 2 — Run business grilling
 
@@ -35,15 +35,15 @@ Ask exactly one question per turn. Each question must:
 2. include a recommended answer and short rationale;
 3. wait for the user's answer before advancing.
 
-Keep the grilling at epic altitude: problem, evidence, target segment, business value, strategic role, outcomes, leading indicators, falsification, MVP learning, scope, rollout, ownership, and business constraints. Defer provider, API, package, schema, infrastructure, library, and architecture decisions to solution design unless a technical constraint changes the business bet itself.
+Keep the grilling at product-requirements level: problem, evidence, target segment, business value, strategic role, outcomes, leading indicators, falsification, MVP learning, scope, rollout, ownership, and business constraints. Defer provider, API, package, schema, infrastructure, library, and architecture decisions to solution design unless a technical constraint changes the business bet itself.
 
-If the user says a target does not matter, record that as an explicit decision rather than manufacturing precision. If the user stops the questions, summarize decisions and unresolved branches. Do not draft or edit the epic until the user confirms shared understanding; a new request to apply the summarized decisions after the grilling also counts as confirmation. The original request to "write an epic" does not bypass this gate.
+If the user says a target does not matter, record that as an explicit decision rather than manufacturing precision. If the user stops the questions, summarize decisions and unresolved branches. Do not draft or edit the PRD until the user confirms shared understanding; a new request to apply the summarized decisions after the grilling also counts as confirmation. The original request to "write a PRD" does not bypass this gate.
 
 Completion criterion: every branch in the business-grilling completion gate is answered, deliberately deferred with an owner and gate, or explicitly rejected by the user; the user has confirmed the shared understanding.
 
-## Stage 3 — Draft the epic
+## Stage 3 — Draft the PRD
 
-Read `references/epic-template.md` and `references/example-epic.md`. Follow the wiki's local schema and link convention.
+Read `references/prd-template.md` and `references/example-prd.md`. Follow the wiki's local schema and link convention.
 
 Draft in this order:
 
@@ -74,25 +74,25 @@ Completion criterion: every checklist item passes or is reported as an explicit,
 
 ## Stage 5 — Bookkeeping
 
-- Save as `epics/EPIC-NNN <Name>.md` using the next free ID, or preserve the ID when rewriting an existing epic.
+- Save as `prds/PRD-NNN <Name>.md` using the next free ID, or preserve the ID when rewriting an existing PRD.
 - Update the wiki index and log when present.
 - Add or update persona backlinks.
-- Update all inbound links when renaming an epic.
-- Create or update the epic's grilling log from `_templates/epic-grilling-log.md` after the shared understanding is confirmed. Store one log per epic at `product/epics/grilling/EPIC-NNN <Name> - Grilling Log.md`; append later sessions and continue the `G-*` sequence.
+- Update all inbound links when renaming a PRD.
+- Create or update the PRD's grilling log from `_templates/prd-grilling-log.md` after the shared understanding is confirmed. Store one log per PRD at `product/prds/grilling/PRD-NNN <Name> - Grilling Log.md`; append later sessions and continue the `G-*` sequence.
 - Record the user-visible decision trail, not hidden reasoning. Summarize confidential evidence without copying source bodies, secrets, personal data, or unnecessary verbatim conversation.
-- Link the epic and grilling log in both directions and register the log in the wiki index and root update log.
+- Link the PRD and grilling log in both directions and register the log in the wiki index and root update log.
 - Preserve sources and downstream task artifacts; report stale downstream artifacts instead of silently rewriting them.
 
-Completion criterion: the epic and grilling log are mutually linked and navigable from the wiki; every grilling decision is represented once; no changed link points to an old name.
+Completion criterion: the PRD and grilling log are mutually linked and navigable from the wiki; every grilling decision is represented once; no changed link points to an old name.
 
 ## Stage 6 — Gate
 
-New epics start as `draft`. A rewritten epic changes status only when the user explicitly approves the transition. Close with both file locations, passed checks, open decisions, stale downstream artifacts, and proposed next lifecycle step.
+New PRDs start as `draft`. A rewritten PRD changes status only when the user explicitly approves the transition. Close with both file locations, passed checks, open decisions, stale downstream artifacts, and proposed next lifecycle step.
 
 ## References
 
 - `references/business-grilling.md` — mandatory sequential business interview and completion gate.
-- `references/epic-template.md` — canonical epic structure.
+- `references/prd-template.md` — canonical PRD structure.
 - `references/quality-checklist.md` — Definition of Ready for review.
-- `references/example-epic.md` — business-first quality bar.
-- `_templates/epic-grilling-log.md` in the target wiki — canonical decision-log structure; do not duplicate it inside the skill.
+- `references/example-prd.md` — business-first quality bar.
+- `_templates/prd-grilling-log.md` in the target wiki — canonical decision-log structure; do not duplicate it inside the skill.

--- a/skills/prd-author/references/business-grilling.md
+++ b/skills/prd-author/references/business-grilling.md
@@ -1,6 +1,6 @@
 # Business Grilling Protocol
 
-Use this protocol before drafting or rewriting an epic. Its purpose is to expose whether the proposed initiative is a real business bet, a weak assumption, or a solution looking for a problem.
+Use this protocol before drafting or rewriting a PRD. Its purpose is to expose whether the proposed initiative is a real business bet, a weak assumption, or a solution looking for a problem.
 
 ## Contents
 
@@ -18,7 +18,7 @@ Use this protocol before drafting or rewriting an epic. Its purpose is to expose
 - Look up discoverable facts before asking. Decisions belong to the user; facts do not.
 - Challenge vague claims until they have a population, evidence status, measure, and timeframe, or are explicitly rejected as irrelevant.
 - Treat "keep up with the market", "improve UX", "increase adoption", and "differentiate" as starting claims, not accepted value.
-- Keep technical solution branches parked for solution design. Record them; do not grill them during epic definition.
+- Keep technical solution branches parked for solution design. Record them; do not grill them during PRD definition.
 - Maintain a structured in-memory ledger for every question: `G-*` ID, branch, question, recommendation, answer, and decision. The ledger becomes the wiki grilling log only after shared understanding is confirmed.
 
 ## Decision tree
@@ -51,7 +51,7 @@ Avoid "users", "customers", or a persona that is broader than the evidence.
 
 ### 3. Strategic role and urgency
 
-Decide whether the epic is:
+Decide whether the PRD is:
 
 - market parity or table stakes;
 - a genuine differentiator;
@@ -103,7 +103,7 @@ Resolve one boundary at a time:
 - default behavior versus deployment-specific configuration;
 - primary journey start and end;
 - explicitly deferred experiences and operator workflows;
-- separate epics that must remain independent.
+- separate PRDs that must remain independent.
 
 Every exclusion needs a reason and destination.
 
@@ -144,7 +144,7 @@ The grilling is complete only when the shared understanding contains:
 
 - a specific target segment and primary persona;
 - a problem statement with evidence separated from assumptions;
-- the epic's strategic role and urgency;
+- the PRD's strategic role and urgency;
 - one primary business outcome and its value path;
 - quantified validation evidence or an explicitly accepted lack of a target;
 - leading indicators distinct from business outcomes;

--- a/skills/prd-author/references/example-prd.md
+++ b/skills/prd-author/references/example-prd.md
@@ -1,14 +1,14 @@
-# Business-first epic example
+# Business-first Product Requirements Document example
 
 This is a fictional quality example. Its numbers illustrate the required specificity; never reuse them without evidence and user confirmation.
 
 ```markdown
 ---
-id: EPIC-002
-type: Epic
+id: PRD-002
+type: Product Requirements Document
 status: analyzing
 owner: "Product"
-epic_type: business
+prd_type: business
 personas:
   - "[Storefront Developer](product/personas/Storefront%20Developer.md)"
   - "[Shopper](product/personas/Shopper.md)"
@@ -20,7 +20,7 @@ updated: 2026-07-01
 
 ## Value Hypothesis
 
-**For** teams evaluating Nimara for consumer storefronts **who** expect credible social proof without buying and integrating another SaaS product, **the** Verified User Reviews epic **is a** built-in verified-purchase review capability **that** prevents a table-stake gap from disqualifying Nimara and gives shoppers trustworthy purchase evidence, **unlike** shipping no reviews or rebuilding a third-party integration per store, **our solution** is open-source, adopter-owned, and usable without a permanently staffed moderation operation.
+**For** teams evaluating Nimara for consumer storefronts **who** expect credible social proof without buying and integrating another SaaS product, **the** Verified User Reviews capability **is a** built-in verified-purchase review capability **that** prevents a table-stake gap from disqualifying Nimara and gives shoppers trustworthy purchase evidence, **unlike** shipping no reviews or rebuilding a third-party integration per store, **our solution** is open-source, adopter-owned, and usable without a permanently staffed moderation operation.
 
 ## Evidence & Assumptions
 
@@ -63,7 +63,7 @@ If at least 4 qualified assessments occur but fewer than 4 accept the capability
 ## Out of Scope
 
 - Photo reviews — fast-follow after the core contribution loop is validated because uploads add storage, moderation, and privacy scope.
-- Vendor ratings and replies — separate marketplace epic because the buyer, workflow, and value differ.
+- Vendor ratings and replies — separate marketplace PRD because the buyer, workflow, and value differ.
 - Review imports and incentives — separate future bets requiring their own evidence.
 
 ## User Stories
@@ -88,7 +88,7 @@ If at least 4 qualified assessments occur but fewer than 4 accept the capability
 
 ## Related Notes
 
-[EPIC-002 Verified User Reviews - Grilling Log](product/epics/grilling/EPIC-002%20Verified%20User%20Reviews%20-%20Grilling%20Log.md)
+[PRD-002 Verified User Reviews - Grilling Log](product/prds/grilling/PRD-002%20Verified%20User%20Reviews%20-%20Grilling%20Log.md)
 [Table Stakes vs Differentiators](product/market/Table%20Stakes%20vs%20Differentiators.md)
 [Storefront Developer](product/personas/Storefront%20Developer.md)
 [Shopper](product/personas/Shopper.md)

--- a/skills/prd-author/references/prd-template.md
+++ b/skills/prd-author/references/prd-template.md
@@ -1,25 +1,25 @@
 ---
-id: EPIC-000
-type: Epic
+id: PRD-000
+type: Product Requirements Document
 status: draft
 owner: ""
-epic_type: business
+prd_type: business
 personas:
   - ""
 created: YYYY-MM-DD
 updated: YYYY-MM-DD
 ---
 
-# Epic Name
+# PRD Name
 
 ## Value Hypothesis
 
-**For** <specific segment> **who** <business need or risk>, **the** <epic name> **is a** <solution category> **that** <business benefit>, **unlike** <current state or alternative>, **our solution** <primary business differentiation>.
+**For** <specific segment> **who** <business need or risk>, **the** <product or capability name> **is a** <solution category> **that** <business benefit>, **unlike** <current state or alternative>, **our solution** <primary business differentiation>.
 
 ## Evidence & Assumptions
 
 - E-1: evidence and what it proves or does not prove
-- A-1 `[ASSUMPTION]`: unproven claim the epic will test
+- A-1 `[ASSUMPTION]`: unproven claim the PRD will test
 
 ## Business Goal & Value
 
@@ -67,5 +67,5 @@ Describe the smallest learning slice, rollout, validation-clock start, negative 
 
 ## Related Notes
 
-[Epic Grilling Log](path/to/epic-grilling-log.md)
+[PRD Grilling Log](path/to/prd-grilling-log.md)
 [Seeding Strategy or Initiative](path/to/note.md)

--- a/skills/prd-author/references/quality-checklist.md
+++ b/skills/prd-author/references/quality-checklist.md
@@ -1,6 +1,6 @@
-# Epic Quality Checklist
+# PRD Quality Checklist
 
-Run every check before presenting or filing the epic. Fix issues that require no decision; report the rest as owned Open Questions.
+Run every check before presenting or filing the PRD. Fix issues that require no decision; report the rest as owned Open Questions.
 
 ## Business grilling gate
 
@@ -12,7 +12,7 @@ Run every check before presenting or filing the epic. Fix issues that require no
 
 ## Identity and audience
 
-- [ ] `id` is a unique `EPIC-NNN`; status, owner, epic type, personas, and dates are filled.
+- [ ] `id` is a unique `PRD-NNN`; status, owner, PRD type, personas, and dates are filled.
 - [ ] The name describes the value or problem space and survives a change in implementation.
 - [ ] The primary segment is specific; adopter/buyer value is distinguished from end-user experience value.
 - [ ] Persona references follow the wiki's local link convention and resolve.
@@ -22,7 +22,7 @@ Run every check before presenting or filing the epic. Fix issues that require no
 - [ ] Evidence states what it proves and does not overclaim attribution.
 - [ ] Every unproven value claim is labeled `[ASSUMPTION]`.
 - [ ] The seven-part value hypothesis is complete.
-- [ ] The epic's strategic role is explicit: parity, differentiation, risk, revenue, retention, adoption, or cost.
+- [ ] The PRD's strategic role is explicit: parity, differentiation, risk, revenue, retention, adoption, or cost.
 - [ ] The value path reaches a business outcome rather than stopping at activity, output, or UX.
 
 ## Measurement and falsification
@@ -39,7 +39,7 @@ Run every check before presenting or filing the epic. Fix issues that require no
 - [ ] Appetite is recorded when the user considers it relevant; otherwise its exclusion is explicit.
 - [ ] Every scope item has an `S-*` ID and stays at capability/behavior level.
 - [ ] Every out-of-scope item says why it is deferred and where it belongs.
-- [ ] Scope does not duplicate or contradict another epic.
+- [ ] Scope does not duplicate or contradict another PRD.
 - [ ] Provider, API, schema, package, infrastructure, library, and hosting decisions remain in solution design.
 
 ## Stories and criteria
@@ -54,6 +54,6 @@ Run every check before presenting or filing the epic. Fix issues that require no
 - [ ] Every risk threatens the hypothesis and has a mitigation or explicit acceptance.
 - [ ] Every open question has an owner and a `before <stage>` gate.
 - [ ] Filename, index, log, Related Notes, persona backlinks, and renamed inbound links are current.
-- [ ] The epic grilling log was created or appended from the wiki template, continues stable `G-*` IDs, and links to the epic in both directions.
+- [ ] The PRD grilling log was created or appended from the wiki template, continues stable `G-*` IDs, and links to the PRD in both directions.
 - [ ] The grilling log contains user-visible decisions only; confidential sources, secrets, personal data, and hidden reasoning were not copied.
 - [ ] Sources were preserved and stale downstream artifacts were reported rather than silently rewritten.

--- a/skills/wiki/wiki-maintenance/SKILL.md
+++ b/skills/wiki/wiki-maintenance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wiki-maintenance
-description: Maintain the llm-wiki knowledge base — ingest a new source into interlinked notes, lint/audit the graph (orphans, dangling links, uncited claims, format drift), record an architecture decision as an ADR, or answer a question from the wiki and file the answer back so knowledge compounds. Use this skill whenever the user wants to add/ingest a document or research into the wiki, audit/lint/clean up the wiki, check for broken [[links]] or orphan notes, record/document an architecture decision (ADR), or ask a question that the wiki should answer (and save the answer). Follows the schema in llm-wiki/AGENTS.md. Do NOT use to write an epic (use epic-definition) or to run QA (use the skills/qa/* skills).
+description: Maintain the llm-wiki knowledge base — ingest a new source into interlinked notes, lint/audit the graph (orphans, dangling links, uncited claims, format drift), record an architecture decision as an ADR, or answer a question from the wiki and file the answer back so knowledge compounds. Use this skill whenever the user wants to add/ingest a document or research into the wiki, audit/lint/clean up the wiki, check for broken [[links]] or orphan notes, record/document an architecture decision (ADR), or ask a question that the wiki should answer (and save the answer). Follows the schema in llm-wiki/AGENTS.md. Do NOT use to write a PRD (use prd-author) or to run QA (use the skills/qa/* skills).
 ---
 
 # Wiki Maintenance
@@ -115,7 +115,7 @@ future readers will ask "why did we do it this way?" about.
 3. **FILL** the Nygard sections — `**Status**` (usually `Accepted`, or `Proposed` if still
    under review), then Context (value-neutral forces) → Decision ("We will …") →
    Consequences (positive *and* negative trade-offs). One decision per note.
-4. **LINK** back to the `solution/` or `epics/` note it supports, and add its `## Related Notes`.
+4. **LINK** back to the `solution/` or `prds/` note it supports, and add its `## Related Notes`.
 5. **REGISTER** it in `[[Decisions MOC]]`'s register (one line) in the same change.
 6. **Superseding, not editing.** To change a decided ADR, write a new one and set the old
    `**Status**` to `Superseded by [[ADR-NNNN …]]` — never rewrite an Accepted ADR in place.


### PR DESCRIPTION
## Summary
- Introduce a structured LLM wiki with product, strategy, quality, and technical reference sections.
- Add and update agent skills for epic definition, PRD authoring, QA triage, wiki maintenance, and related templates.
- Include supporting scripts, task metadata, and repository ignore rules to keep the new documentation workflow organized.

## Testing
- Not run (not requested)