### PR TITLE
docs: document trunk break-glass path

### DIFF
--- a/docs/03-Release-workflow.md
+++ b/docs/03-Release-workflow.md
@@ -43,8 +43,10 @@ Before merging:
 - Bring the branch up to date with `main`.
 - Complete risk-appropriate testing against the preview deployment.
 
-GitHub squash-merges the change and deletes the branch. Do not commit directly to `main` except
-through the documented break-glass incident procedure.
+GitHub squash-merges the change and deletes the branch. Direct pushes to `main` have no bypass.
+During an active incident, only a member of the GitHub `Admins` team may use the ruleset's
+pull-request-only bypass. Keep the change in a PR, use a squash merge, and record the actor, reason,
+exact SHA, skipped requirements, and recovery owner in the incident record.
 
 ## Additional QA
 

--- a/llm-wiki/log.md
+++ b/llm-wiki/log.md
@@ -28,6 +28,7 @@
 
 ## 2026-07-23
 
-- **Update**: Replaced branch-promotion guidance in OPS-0008 with the CI-gated release-from-trunk and production rollback procedure anchored to release commit `407da55cabebee44ec910d1a96261934b4cab963`.
-- **Maintenance**: Documented the `Admins` team pull-request-only break-glass path; direct pushes to `main` have no bypass.
+- **Update**: Replaced branch-promotion guidance in OPS-0008 with the CI-gated release-from-trunk and production rollback procedure anchored to implementation commit `241c4bbfa932f0a672b9422aed98489aaba76d1c`.
 - **Maintenance**: Reconciled the operations register, root index, and QA environment matrix with `main` as the only long-lived development branch.
+- **Provenance correction**: Re-anchored OPS-0008 from the deleted migration branch to durable release commit `407da55cabebee44ec910d1a96261934b4cab963`.
+- **Maintenance**: Documented the `Admins` team pull-request-only break-glass path; direct pushes to `main` have no bypass.

--- a/llm-wiki/log.md
+++ b/llm-wiki/log.md
@@ -28,5 +28,6 @@
 
 ## 2026-07-23
 
-- **Update**: Replaced branch-promotion guidance in OPS-0008 with the CI-gated release-from-trunk and production rollback procedure anchored to implementation commit `241c4bbfa932f0a672b9422aed98489aaba76d1c`.
+- **Update**: Replaced branch-promotion guidance in OPS-0008 with the CI-gated release-from-trunk and production rollback procedure anchored to release commit `407da55cabebee44ec910d1a96261934b4cab963`.
+- **Maintenance**: Documented the `Admins` team pull-request-only break-glass path; direct pushes to `main` have no bypass.
 - **Maintenance**: Reconciled the operations register, root index, and QA environment matrix with `main` as the only long-lived development branch.

--- a/llm-wiki/operations/OPS-0008 Trunk Release and Production Rollback.md
+++ b/llm-wiki/operations/OPS-0008 Trunk Release and Production Rollback.md
@@ -77,8 +77,10 @@ deployment without rewriting published Git history.
 
 # Escalation
 
-- A direct or bypass push to `main` is a break-glass event. Confirm the actor, reason, exact SHA,
-  checks, and recovery owner, then preserve that evidence in the incident record.
+- Direct pushes to `main` have no bypass. During an active incident, only a member of the GitHub
+  `Admins` team may use the ruleset's pull-request-only bypass. Keep the change in a PR, use a
+  squash merge, and preserve the actor, reason, exact SHA, skipped requirements, and recovery owner
+  in the incident record.
 - The workflow runs `pnpm dlx semantic-release` without a repository-pinned semantic-release
   version. Investigate unexpected versioning or plugin behavior before retrying a failed release.
 - Vercel can begin processing a `main` deployment independently of the post-merge GitHub workflow.
@@ -96,10 +98,10 @@ deployment without rewriting published Git history.
 # Provenance
 
 - This trunk release and rollback contract is anchored at exact implementation commit
-  [`241c4bbfa932f0a672b9422aed98489aaba76d1c`](https://github.com/mirumee/nimara-ecommerce/tree/241c4bbfa932f0a672b9422aed98489aaba76d1c),
+  [`407da55cabebee44ec910d1a96261934b4cab963`](https://github.com/mirumee/nimara-ecommerce/tree/407da55cabebee44ec910d1a96261934b4cab963),
   including the
-  [documented trunk workflow](https://github.com/mirumee/nimara-ecommerce/blob/241c4bbfa932f0a672b9422aed98489aaba76d1c/docs/03-Release-workflow.md),
-  [main CI workflow](https://github.com/mirumee/nimara-ecommerce/blob/241c4bbfa932f0a672b9422aed98489aaba76d1c/.github/workflows/main.yaml),
-  [CI-gated semantic-release workflow](https://github.com/mirumee/nimara-ecommerce/blob/241c4bbfa932f0a672b9422aed98489aaba76d1c/.github/workflows/release.yaml),
+  [documented trunk workflow](https://github.com/mirumee/nimara-ecommerce/blob/407da55cabebee44ec910d1a96261934b4cab963/docs/03-Release-workflow.md),
+  [main CI workflow](https://github.com/mirumee/nimara-ecommerce/blob/407da55cabebee44ec910d1a96261934b4cab963/.github/workflows/main.yaml),
+  [CI-gated semantic-release workflow](https://github.com/mirumee/nimara-ecommerce/blob/407da55cabebee44ec910d1a96261934b4cab963/.github/workflows/release.yaml),
   and
-  [commit-aware QA deployment](https://github.com/mirumee/nimara-ecommerce/blob/241c4bbfa932f0a672b9422aed98489aaba76d1c/.github/workflows/deploy.yaml).
+  [commit-aware QA deployment](https://github.com/mirumee/nimara-ecommerce/blob/407da55cabebee44ec910d1a96261934b4cab963/.github/workflows/deploy.yaml).


### PR DESCRIPTION
## Summary

- document the enforced `Admins` team pull-request-only break-glass path
- state explicitly that direct pushes to `main` have no bypass
- anchor OPS-0008 provenance to durable release commit `407da55c` / `v2.1.1`
- reconcile the LLM-wiki update log and search index

## Testing

- `pnpm exec prettier --check` for changed documents
- `pnpm turbo run build --filter=docs --force`
- LLM-wiki local-link audit (86 Markdown files / 453 links)
- QMD update, embed, and search verification

## Rollback

Revert this documentation-only PR; hosted rules remain unchanged.