### PR TITLE
Generate relative CMS navigation links

### DIFF
--- a/packages/infrastructure/src/lib/serializers/cms-menu.ts
+++ b/packages/infrastructure/src/lib/serializers/cms-menu.ts
@@ -17,9 +17,7 @@ const createMenuItemUrl = (
   page?: { slug: string } | null,
   locale?: string,
 ): string => {
-  const baseUrl = locale
-    ? `${process.env.NEXT_PUBLIC_STOREFRONT_URL}${locale}`
-    : process.env.NEXT_PUBLIC_STOREFRONT_URL;
+  const baseUrl = locale ?? "";
 
   if (page?.slug) {
     return `${baseUrl}/page/${page.slug}`;


### PR DESCRIPTION
## Summary

- generate relative URLs for CMS category, collection, and page links
- preserve locale prefixes
- keep navigation on the current Vercel preview domain
- keep external URLs absolute

## Problem

CMS navigation links were generated using `NEXT_PUBLIC_STOREFRONT_URL`.

Since this variable points to `https://dev.nimara.store` in Preview deployments, clicking a navigation item redirected users away from the current Vercel preview.

## Solution

Internal CMS navigation links are now generated as relative paths. The browser resolves them against the current domain, so they work correctly on local, preview, and production deployments.

`NEXT_PUBLIC_STOREFRONT_URL` remains unchanged and continues to support features requiring absolute URLs.

## Testing

- storefront tests: 25 passed
- ESLint passed
- verified category, collection, page, localized, and external links