### PR TITLE
feat: optimistic cart updates

### DIFF
--- a/apps/storefront/src/app/[locale]/(main)/cart/_components/marketplace-cart-view.tsx
+++ b/apps/storefront/src/app/[locale]/(main)/cart/_components/marketplace-cart-view.tsx
@@ -111,6 +111,7 @@ export const MarketplaceCartView = async (props: CartViewProps) => {
         paths={{
           checkout: paths.checkout,
           checkoutSignIn: paths.checkoutSignIn,
+          home: paths.home,
         }}
       />
     </CartShell>

--- a/apps/storefront/src/app/[locale]/(main)/layout.tsx
+++ b/apps/storefront/src/app/[locale]/(main)/layout.tsx
@@ -1,3 +1,5 @@
+import { CartCountProvider } from "@nimara/features/cart/shared/providers/cart-count-provider";
+
 import { CACHE_TTL } from "@/config";
 import { Footer } from "@/features/footer";
 import { Header } from "@/features/header";
@@ -26,7 +28,7 @@ export default async function Layout({ children }: LayoutProps<"/[locale]">) {
   });
 
   return (
-    <>
+    <CartCountProvider>
       <div className="sticky top-0 isolate z-50 bg-background py-4 transition-colors md:pb-0">
         <Header />
         <Navigation menu={resultMenu.data?.menu} />
@@ -35,6 +37,6 @@ export default async function Layout({ children }: LayoutProps<"/[locale]">) {
         {children}
       </main>
       <Footer />
-    </>
+    </CartCountProvider>
   );
 }

--- a/apps/storefront/src/features/header/header.tsx
+++ b/apps/storefront/src/features/header/header.tsx
@@ -1,6 +1,5 @@
 import { User } from "lucide-react";
 import { getTranslations } from "next-intl/server";
-import { Suspense } from "react";
 
 import { LocalizedLink } from "@nimara/i18n/routing";
 import { Button } from "@nimara/ui/components/button";
@@ -18,7 +17,6 @@ import { Logo } from "./logo";
 import { MobileSearch } from "./mobile-search";
 import { MobileSideMenu } from "./mobile-side-menu";
 import { SearchForm } from "./search-form";
-import { ShoppingBagIcon } from "./shopping-bag-icon";
 import { ShoppingBagIconWithCount } from "./shopping-bag-icon-with-count";
 import { ThemeToggle } from "./theme-toggle";
 
@@ -138,9 +136,7 @@ export const Header = async () => {
               </LocalizedLink>
             </Button>
 
-            <Suspense fallback={<ShoppingBagIcon />}>
-              <ShoppingBagIconWithCount count={checkoutLinesCount} />
-            </Suspense>
+            <ShoppingBagIconWithCount count={checkoutLinesCount} />
           </div>
         </div>
       </div>

--- a/apps/storefront/src/features/header/mobile-side-menu.tsx
+++ b/apps/storefront/src/features/header/mobile-side-menu.tsx
@@ -6,6 +6,7 @@ import { type ReactNode, useEffect, useState } from "react";
 
 import type { Menu } from "@nimara/domain/objects/Menu";
 import type { User } from "@nimara/domain/objects/User";
+import { useCartCount } from "@nimara/features/cart/shared/providers/cart-count-provider";
 import { cn } from "@nimara/foundation/lib/cn";
 import { MobileNavigation } from "@nimara/foundation/navigation/mobile-navigation";
 import { LocalizedLink, usePathname } from "@nimara/i18n/routing";
@@ -42,6 +43,8 @@ export const MobileSideMenu = ({
   const pathname = usePathname();
   const t = useTranslations();
   const region = useCurrentRegion();
+  const { resolveCount } = useCartCount();
+  const linesCount = resolveCount(checkoutLinesCount);
 
   const handleMenuItemClick = (isMenuItemClicked: boolean) => {
     setIsOpen(!isMenuItemClicked);
@@ -74,7 +77,7 @@ export const MobileSideMenu = ({
                 className={cn(
                   "flex w-full items-center justify-between gap-4 pb-4 sm:hidden",
                   {
-                    "mt-2": checkoutLinesCount,
+                    "mt-2": linesCount,
                   },
                 )}
               >

--- a/apps/storefront/src/features/header/shopping-bag-icon-with-count.tsx
+++ b/apps/storefront/src/features/header/shopping-bag-icon-with-count.tsx
@@ -1,13 +1,16 @@
-import { connection } from "next/server";
+"use client";
+
+import { useCartCount } from "@nimara/features/cart/shared/providers/cart-count-provider";
 
 import { ShoppingBagIcon } from "./shopping-bag-icon";
 
-export const ShoppingBagIconWithCount = async ({
-  count,
+export const ShoppingBagIconWithCount = ({
+  count: serverCount,
 }: {
   count: number;
 }) => {
-  await connection();
+  const { resolveCount } = useCartCount();
+  const count = resolveCount(serverCount);
 
   return (
     <ShoppingBagIcon count={count}>

--- a/packages/features/src/cart/shared/components/cart-details.tsx
+++ b/packages/features/src/cart/shared/components/cart-details.tsx
@@ -2,19 +2,30 @@
 
 import { useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useEffect, useRef, useState } from "react";
+import {
+  useEffect,
+  useOptimistic,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
 
 import { type Cart } from "@nimara/domain/objects/Cart";
 import type { AsyncResult } from "@nimara/domain/objects/Result";
 import { type User } from "@nimara/domain/objects/User";
+import { EmptyCart } from "@nimara/features/cart/shared/components/empty-cart";
+import { applyOptimisticCartAction } from "@nimara/features/cart/shared/optimistic";
+import { useCartCount } from "@nimara/features/cart/shared/providers/cart-count-provider";
 import { ShoppingBag } from "@nimara/features/shared/shopping-bag/shopping-bag";
-import { LocalizedLink, useRouter } from "@nimara/i18n/routing";
+import { LocalizedLink } from "@nimara/i18n/routing";
 import { getTrackingService } from "@nimara/infrastructure/tracking/service";
 import { Button } from "@nimara/ui/components/button";
 import { useToast } from "@nimara/ui/hooks";
 import { cn } from "@nimara/ui/lib/utils";
 
 const tracking = getTrackingService();
+
+const QUANTITY_REQUEST_DELAY_MS = 500;
 
 export interface CartDetailsProps {
   cart: Cart;
@@ -33,6 +44,7 @@ export interface CartDetailsProps {
   paths: {
     checkout: string;
     checkoutSignIn: string;
+    home: string;
   };
   user: User | null;
   vendorIdNames?: Record<string, string>;
@@ -50,8 +62,6 @@ export const CartDetails = ({
   paths,
 }: CartDetailsProps) => {
   const t = useTranslations();
-  const router = useRouter();
-  const [isProcessing, setIsProcessing] = useState(false);
   const { toast } = useToast();
   const params = useSearchParams();
   const redirectReason = params.get("redirectReason") as
@@ -59,28 +69,85 @@ export const CartDetails = ({
     | "VARIANT_NOT_AVAILABLE"
     | null;
 
-  const prevCartVersion = useRef(cart.lines.length);
+  const [optimisticCart, applyOptimistic] = useOptimistic(
+    cart,
+    applyOptimisticCartAction,
+  );
+  const [, startTransition] = useTransition();
+  const requestedQuantities = useRef(new Map<string, number>());
+  const { applyCountDelta } = useCartCount();
+
+  const inFlightRequests = useRef(0);
+  const [isMutating, setIsMutating] = useState(false);
+
+  const beginRequest = () => {
+    inFlightRequests.current += 1;
+    setIsMutating(true);
+  };
+
+  const endRequest = () => {
+    inFlightRequests.current = Math.max(inFlightRequests.current - 1, 0);
+
+    if (!inFlightRequests.current) {
+      setIsMutating(false);
+    }
+  };
+
   const isCartValid = ![
     ...cart.problems.insufficientStock,
     ...cart.problems.variantNotAvailable,
   ].length;
 
-  const isDisabled = isProcessing || !isCartValid;
+  const isDisabled = isMutating || !isCartValid;
   const resolveCheckoutIdForLine = (lineId: string): string =>
     lineCheckoutIdMap?.[lineId] ?? cart.id;
 
+  const showErrors = (errors: { code: string }[]) =>
+    errors.forEach((error) => {
+      toast({
+        description: t(`errors.${error.code}`),
+        variant: "destructive",
+      });
+    });
+
   const handleLineQuantityChange = async (lineId: string, quantity: number) => {
-    setIsProcessing(true);
     const checkoutId = resolveCheckoutIdForLine(lineId);
     const line = cart.lines.find((entry) => entry.id === lineId);
 
-    const result = await onLineQuantityChange({
-      cartId: checkoutId,
-      lineId,
-      quantity,
-    });
+    requestedQuantities.current.set(lineId, quantity);
+    beginRequest();
 
-    if (result.ok) {
+    startTransition(async () => {
+      applyOptimistic({ type: "update", lineId, quantity });
+
+      applyCountDelta(lineId, quantity - (line?.quantity ?? 0));
+
+      await new Promise((resolve) =>
+        setTimeout(resolve, QUANTITY_REQUEST_DELAY_MS),
+      );
+
+      if (requestedQuantities.current.get(lineId) !== quantity) {
+        endRequest();
+
+        return;
+      }
+
+      requestedQuantities.current.delete(lineId);
+
+      const result = await onLineQuantityChange({
+        cartId: checkoutId,
+        lineId,
+        quantity,
+      });
+
+      endRequest();
+
+      if (!result.ok) {
+        showErrors(result.errors);
+
+        return;
+      }
+
       if (line && quantity !== line.quantity) {
         const isQuantityAdd = quantity > line.quantity;
         const changedQuantity = Math.abs(quantity - line.quantity);
@@ -104,60 +171,45 @@ export const CartDetails = ({
       }
 
       await onCartUpdate(checkoutId);
-      setIsProcessing(false);
-
-      return;
-    }
-
-    result.errors.forEach((error) => {
-      toast({
-        description: t(`errors.${error.code}`),
-        variant: "destructive",
-      });
     });
   };
 
   const handleLineDelete = async (lineId: string) => {
-    setIsProcessing(true);
+    if (!optimisticCart.lines.some((line) => line.id === lineId)) {
+      return;
+    }
+
     const checkoutId = resolveCheckoutIdForLine(lineId);
     const deletedLine = cart.lines.find((line) => line.id === lineId);
 
-    const result = await onLineDelete({
-      cartId: checkoutId,
-      lineId,
-    });
+    requestedQuantities.current.delete(lineId);
+    beginRequest();
 
-    if (result.ok) {
+    startTransition(async () => {
+      applyOptimistic({ type: "delete", lineId });
+      applyCountDelta(lineId, -(deletedLine?.quantity ?? 0));
+
+      const result = await onLineDelete({ cartId: checkoutId, lineId });
+
+      endRequest();
+
+      if (!result.ok) {
+        showErrors(result.errors);
+
+        return;
+      }
+
       if (deletedLine) {
         void tracking.trackRemoveFromCart({ line: deletedLine });
       }
 
       await onCartUpdate(checkoutId);
-      router.refresh();
-    } else {
-      result.errors.forEach((error) => {
-        toast({
-          description: t(`errors.${error.code}`),
-          variant: "destructive",
-        });
-      });
-      setIsProcessing(false);
-    }
+    });
   };
 
   useEffect(() => {
     void tracking.trackViewCart({ cart });
   }, []);
-
-  // Unblock UI when cart updates
-  useEffect(() => {
-    const cartVersion = cart.lines.length;
-
-    if (isProcessing && prevCartVersion.current !== cartVersion) {
-      setIsProcessing(false);
-      prevCartVersion.current = cartVersion;
-    }
-  }, [cart, isProcessing]);
 
   useEffect(() => {
     if (redirectReason) {
@@ -170,6 +222,10 @@ export const CartDetails = ({
     }
   }, [redirectReason, cart.id, toast, t, onCartUpdate]);
 
+  if (!optimisticCart.lines.length) {
+    return <EmptyCart paths={{ home: paths.home }} />;
+  }
+
   return (
     <div className="space-y-12">
       <ShoppingBag>
@@ -180,18 +236,17 @@ export const CartDetails = ({
           onLineDelete={handleLineDelete}
           problems={cart.problems}
           vendorIdNames={vendorIdNames}
-          lines={cart.lines}
-          isDisabled={isProcessing}
+          lines={optimisticCart.lines}
         />
 
         <hr className="border-stone-200" />
 
         <ShoppingBag.Pricing>
-          <ShoppingBag.Subtotal price={cart.subtotal} />
+          <ShoppingBag.Subtotal price={optimisticCart.subtotal} />
         </ShoppingBag.Pricing>
       </ShoppingBag>
       <div className="w-full text-center">
-        <Button asChild size="lg" disabled={isDisabled} loading={isProcessing}>
+        <Button asChild size="lg" disabled={isDisabled} loading={isMutating}>
           <LocalizedLink
             href={!!user ? paths.checkout : paths.checkoutSignIn}
             className={cn({

--- a/packages/features/src/cart/shared/optimistic.test.ts
+++ b/packages/features/src/cart/shared/optimistic.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+
+import { type Cart } from "@nimara/domain/objects/Cart";
+import { type Line, type PriceType } from "@nimara/domain/objects/common";
+
+import { applyOptimisticCartAction } from "./optimistic";
+
+const createLine = ({
+  id,
+  quantity,
+  unitAmount,
+  type = "gross",
+}: {
+  id: string;
+  quantity: number;
+  type?: PriceType;
+  unitAmount: number;
+}): Line => ({
+  id,
+  quantity,
+  thumbnail: null,
+  total: { amount: unitAmount * quantity, currency: "USD", type },
+  undiscountedTotalPrice: { amount: unitAmount * quantity, currency: "USD" },
+  product: {
+    id: `product-${id}`,
+    name: `Product ${id}`,
+    slug: `product-${id}`,
+  },
+  variant: {
+    discount: null,
+    id: `variant-${id}`,
+    maxQuantity: 10,
+    name: `Variant ${id}`,
+    selectionAttributes: [],
+    sku: `sku-${id}`,
+  },
+});
+
+const createCart = (lines: Line[], overrides: Partial<Cart> = {}): Cart => {
+  const linesTotal = lines.reduce((sum, line) => sum + line.total.amount, 0);
+
+  return {
+    id: "checkout-id",
+    lines,
+    linesCount: lines.length,
+    linesQuantityCount: lines.reduce((sum, line) => sum + line.quantity, 0),
+    problems: { insufficientStock: [], variantNotAvailable: [] },
+    subtotal: { amount: linesTotal, currency: "USD" },
+    total: { amount: linesTotal, currency: "USD" },
+    ...overrides,
+  };
+};
+
+describe("applyOptimisticCartAction", () => {
+  it("rescales line prices when quantity increases", () => {
+    const cart = createCart([
+      createLine({ id: "1", quantity: 2, unitAmount: 15 }),
+    ]);
+
+    const result = applyOptimisticCartAction(cart, {
+      type: "update",
+      lineId: "1",
+      quantity: 3,
+    });
+
+    expect(result.lines[0]?.quantity).toBe(3);
+    expect(result.lines[0]?.total.amount).toBe(45);
+    expect(result.lines[0]?.undiscountedTotalPrice.amount).toBe(45);
+    expect(result.linesQuantityCount).toBe(3);
+    expect(result.subtotal.amount).toBe(45);
+    expect(result.total.amount).toBe(45);
+  });
+
+  it("leaves other lines untouched", () => {
+    const otherLine = createLine({ id: "2", quantity: 1, unitAmount: 20 });
+    const cart = createCart([
+      createLine({ id: "1", quantity: 2, unitAmount: 15 }),
+      otherLine,
+    ]);
+
+    const result = applyOptimisticCartAction(cart, {
+      type: "update",
+      lineId: "1",
+      quantity: 1,
+    });
+
+    expect(result.lines[1]).toBe(otherLine);
+    expect(result.subtotal.amount).toBe(35);
+  });
+
+  it("composes consecutive updates without drifting the unit price", () => {
+    const cart = createCart([
+      createLine({ id: "1", quantity: 1, unitAmount: 12.5 }),
+    ]);
+
+    const result = [2, 3, 4].reduce(
+      (acc, quantity) =>
+        applyOptimisticCartAction(acc, {
+          type: "update",
+          lineId: "1",
+          quantity,
+        }),
+      cart,
+    );
+
+    expect(result.lines[0]?.total.amount).toBeCloseTo(50);
+    expect(result.subtotal.amount).toBeCloseTo(50);
+  });
+
+  it("drops the line and its value on delete", () => {
+    const cart = createCart([
+      createLine({ id: "1", quantity: 2, unitAmount: 15 }),
+      createLine({ id: "2", quantity: 1, unitAmount: 20 }),
+    ]);
+
+    const result = applyOptimisticCartAction(cart, {
+      type: "delete",
+      lineId: "1",
+    });
+
+    expect(result.lines).toHaveLength(1);
+    expect(result.linesCount).toBe(1);
+    expect(result.linesQuantityCount).toBe(1);
+    expect(result.subtotal.amount).toBe(20);
+  });
+
+  it("shifts a net based subtotal in the gross basis it was serialized with", () => {
+    const cart = createCart(
+      [createLine({ id: "1", quantity: 2, unitAmount: 100, type: "net" })],
+      {
+        subtotal: { amount: 246, currency: "USD" },
+        total: { amount: 246, currency: "USD" },
+      },
+    );
+
+    const result = applyOptimisticCartAction(cart, {
+      type: "update",
+      lineId: "1",
+      quantity: 3,
+    });
+
+    expect(result.lines[0]?.total.amount).toBe(300);
+    expect(result.subtotal.amount).toBeCloseTo(369);
+  });
+
+  it("keeps totals non negative and stable for an empty cart", () => {
+    const cart = createCart([
+      createLine({ id: "1", quantity: 1, unitAmount: 10 }),
+    ]);
+
+    const result = applyOptimisticCartAction(cart, {
+      type: "delete",
+      lineId: "1",
+    });
+
+    expect(result.lines).toHaveLength(0);
+    expect(result.subtotal.amount).toBe(0);
+    expect(result.total.amount).toBe(0);
+    expect(
+      applyOptimisticCartAction(result, { type: "delete", lineId: "1" })
+        .subtotal.amount,
+    ).toBe(0);
+  });
+
+  it("ignores an unknown line id", () => {
+    const cart = createCart([
+      createLine({ id: "1", quantity: 2, unitAmount: 15 }),
+    ]);
+
+    const result = applyOptimisticCartAction(cart, {
+      type: "update",
+      lineId: "missing",
+      quantity: 5,
+    });
+
+    expect(result.lines[0]?.quantity).toBe(2);
+    expect(result.subtotal.amount).toBe(30);
+  });
+});

--- a/packages/features/src/cart/shared/optimistic.ts
+++ b/packages/features/src/cart/shared/optimistic.ts
@@ -1,0 +1,74 @@
+import { type Cart } from "@nimara/domain/objects/Cart";
+import { type Line } from "@nimara/domain/objects/common";
+
+export type OptimisticCartAction =
+  | { lineId: string; quantity: number; type: "update" }
+  | { lineId: string; type: "delete" };
+
+const rescale = <T extends { amount: number }>(
+  price: T,
+  quantity: number,
+  newQuantity: number,
+): T => ({
+  ...price,
+  amount: quantity > 0 ? (price.amount / quantity) * newQuantity : 0,
+});
+
+const applyLineQuantity = (line: Line, quantity: number): Line => ({
+  ...line,
+  quantity,
+  total: rescale(line.total, line.quantity, quantity),
+  undiscountedTotalPrice: rescale(
+    line.undiscountedTotalPrice,
+    line.quantity,
+    quantity,
+  ),
+});
+
+const recalculate = (cart: Cart, lines: Line[]): Cart => {
+  const linesTotal = cart.lines.reduce(
+    (sum, line) => sum + line.total.amount,
+    0,
+  );
+  const nextLinesTotal = lines.reduce(
+    (sum, line) => sum + line.total.amount,
+    0,
+  );
+
+  const basis = linesTotal > 0 ? cart.subtotal.amount / linesTotal : 1;
+  const delta = (nextLinesTotal - linesTotal) * basis;
+
+  return {
+    ...cart,
+    lines,
+    linesCount: lines.length,
+    linesQuantityCount: lines.reduce((sum, line) => sum + line.quantity, 0),
+    subtotal: {
+      ...cart.subtotal,
+      amount: Math.max(cart.subtotal.amount + delta, 0),
+    },
+
+    total: { ...cart.total, amount: Math.max(cart.total.amount + delta, 0) },
+  };
+};
+
+export const applyOptimisticCartAction = (
+  cart: Cart,
+  action: OptimisticCartAction,
+): Cart => {
+  if (action.type === "delete") {
+    return recalculate(
+      cart,
+      cart.lines.filter((line) => line.id !== action.lineId),
+    );
+  }
+
+  const { lineId, quantity } = action;
+
+  return recalculate(
+    cart,
+    cart.lines.map((line) =>
+      line.id === lineId ? applyLineQuantity(line, quantity) : line,
+    ),
+  );
+};

--- a/packages/features/src/cart/shared/providers/cart-count-provider.tsx
+++ b/packages/features/src/cart/shared/providers/cart-count-provider.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useMemo,
+  useOptimistic,
+} from "react";
+
+interface CartCountContextValue {
+  /**
+   * Reports the pending cart lines quantity change for `key`, expressed against
+   * the server rendered count. Must be called inside a transition - the entry
+   * is discarded once that transition settles and the revalidated count takes
+   * over.
+   *
+   * Reporting the same `key` again replaces the previous entry, so a caller
+   * that repeats a change for one line (a quantity input being typed into)
+   * should key by line id, while a caller whose changes accumulate (adding the
+   * same variant twice) needs a distinct key per change.
+   */
+  applyCountDelta: (key: string, delta: number) => void;
+  /** Applies the pending changes to a server rendered cart lines quantity. */
+  resolveCount: (serverCount: number) => number;
+}
+
+const CartCountContext = createContext<CartCountContextValue | null>(null);
+
+const NO_PENDING_DELTAS: ReadonlyMap<string, number> = new Map();
+
+/**
+ * Lets cart mutations anywhere in the tree update the cart counters in the
+ * header right away, instead of waiting for revalidation.
+ *
+ * It holds pending deltas rather than the count itself, so the server rendered
+ * count stays the single source of truth and nothing has to be reconciled by
+ * hand when it changes.
+ */
+export const CartCountProvider = ({ children }: { children: ReactNode }) => {
+  const [pendingDeltas, applyCountDelta] = useOptimistic(
+    NO_PENDING_DELTAS,
+    (deltas, [key, delta]: [string, number]) =>
+      new Map(deltas).set(key, delta) as ReadonlyMap<string, number>,
+  );
+
+  const value = useMemo(() => {
+    const pendingDelta = [...pendingDeltas.values()].reduce(
+      (sum, delta) => sum + delta,
+      0,
+    );
+
+    return {
+      applyCountDelta: (key: string, delta: number) =>
+        applyCountDelta([key, delta]),
+      resolveCount: (serverCount: number) =>
+        Math.max(serverCount + pendingDelta, 0),
+    };
+  }, [pendingDeltas, applyCountDelta]);
+
+  return (
+    <CartCountContext.Provider value={value}>
+      {children}
+    </CartCountContext.Provider>
+  );
+};
+
+export const useCartCount = () => {
+  const context = useContext(CartCountContext);
+
+  if (!context) {
+    throw new Error("useCartCount must be used within a <CartCountProvider />");
+  }
+
+  return context;
+};

--- a/packages/features/src/cart/shop-basic-cart/standard.tsx
+++ b/packages/features/src/cart/shop-basic-cart/standard.tsx
@@ -48,6 +48,7 @@ export const StandardCartView = async (props: CartViewProps) => {
               paths={{
                 checkout: paths.checkout,
                 checkoutSignIn: paths.checkoutSignIn,
+                home: paths.home,
               }}
             />
           )}

--- a/packages/features/src/product-detail-page/shared/components/add-to-bag.tsx
+++ b/packages/features/src/product-detail-page/shared/components/add-to-bag.tsx
@@ -2,11 +2,12 @@
 
 import { PlusCircle } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useTransition } from "react";
 
 import { type Price } from "@nimara/domain/objects/common";
 import { type BaseError } from "@nimara/domain/objects/Error";
 import { type Product } from "@nimara/domain/objects/Product";
+import { useCartCount } from "@nimara/features/cart/shared/providers/cart-count-provider";
 import { LocalizedLink } from "@nimara/i18n/routing";
 import { type MessagePath } from "@nimara/i18n/types";
 import { getTrackingService } from "@nimara/infrastructure/tracking/service";
@@ -17,6 +18,12 @@ import { useToast } from "@nimara/ui/hooks";
 import { type AddToBagAction } from "../types";
 
 const tracking = getTrackingService();
+
+const ADD_TO_BAG_BATCH_DELAY_MS = 400;
+
+let pendingAddRequests: Promise<unknown> = Promise.resolve();
+
+type PendingAdd = { key: string; quantity: number; variantId: string };
 
 type AddToBagProps = {
   addToBagAction: AddToBagAction;
@@ -39,48 +46,88 @@ export const AddToBag = ({
 }: AddToBagProps) => {
   const t = useTranslations();
   const { toast } = useToast();
-  const [isProcessing, setIsProcessing] = useState(false);
+  const [, startTransition] = useTransition();
+  const { applyCountDelta } = useCartCount();
+  const batchCounter = useRef(0);
+  const pendingAdd = useRef<PendingAdd | null>(null);
 
-  const handleProductAdd = async () => {
-    setIsProcessing(true);
+  const handleProductAdd = () => {
+    // Switching variants ends the current batch rather than adding to it.
+    const batch =
+      pendingAdd.current?.variantId === variantId
+        ? pendingAdd.current
+        : {
+            key: `add:${variantId}:${(batchCounter.current += 1)}`,
+            quantity: 0,
+            variantId,
+          };
+    const quantity = batch.quantity + 1;
 
-    const resultLinesAdd = await addToBagAction({
-      clientProductVendorId: productVendorId,
-      variantId,
+    pendingAdd.current = { ...batch, quantity };
+
+    const addedToast = toast({
+      description: t("common.product-added"),
+      action: (
+        <ToastAction altText={t("common.go-to-bag")} asChild>
+          <LocalizedLink href={cartPath} className="whitespace-nowrap">
+            {t("common.go-to-bag")}
+          </LocalizedLink>
+        </ToastAction>
+      ),
     });
 
-    if (!resultLinesAdd.ok) {
-      resultLinesAdd.errors.forEach((error: BaseError) => {
-        if (error.field) {
-          toast({
-            description: t(`errors.${error.field}` as MessagePath),
-            variant: "destructive",
-          });
-        } else {
-          toast({
-            description: t(`errors.${error.code}` as MessagePath),
-            variant: "destructive",
-          });
-        }
-      });
-    } else {
-      if (price) {
-        void tracking.trackAddToCart({ product, price, quantity: 1 });
+    startTransition(async () => {
+      applyCountDelta(batch.key, quantity);
+
+      await new Promise((resolve) =>
+        setTimeout(resolve, ADD_TO_BAG_BATCH_DELAY_MS),
+      );
+
+      if (
+        pendingAdd.current?.key !== batch.key ||
+        pendingAdd.current.quantity !== quantity
+      ) {
+        return;
       }
 
-      toast({
-        description: t("common.product-added"),
-        action: (
-          <ToastAction altText={t("common.go-to-bag")} asChild>
-            <LocalizedLink href={cartPath} className="whitespace-nowrap">
-              {t("common.go-to-bag")}
-            </LocalizedLink>
-          </ToastAction>
-        ),
-      });
-    }
+      pendingAdd.current = null;
 
-    setIsProcessing(false);
+      const request = pendingAddRequests.then(() =>
+        addToBagAction({
+          clientProductVendorId: productVendorId,
+          variantId,
+          quantity,
+        }),
+      );
+
+      pendingAddRequests = request.catch(() => undefined);
+
+      const resultLinesAdd = await request;
+
+      if (!resultLinesAdd.ok) {
+        addedToast.dismiss();
+
+        resultLinesAdd.errors.forEach((error: BaseError) => {
+          if (error.field) {
+            toast({
+              description: t(`errors.${error.field}` as MessagePath),
+              variant: "destructive",
+            });
+          } else {
+            toast({
+              description: t(`errors.${error.code}` as MessagePath),
+              variant: "destructive",
+            });
+          }
+        });
+
+        return;
+      }
+
+      if (price) {
+        void tracking.trackAddToCart({ product, price, quantity });
+      }
+    });
   };
 
   const handleNotifyMe = useCallback(async () => {
@@ -94,9 +141,8 @@ export const AddToBag = ({
   return (
     <Button
       className="w-full transition-[background-color]"
-      disabled={!variantId || isProcessing}
+      disabled={!variantId}
       onClick={isVariantAvailable ? handleProductAdd : handleNotifyMe}
-      loading={isProcessing}
     >
       {isVariantAvailable ? (
         <>

--- a/packages/features/src/shared/shopping-bag/components/line.tsx
+++ b/packages/features/src/shared/shopping-bag/components/line.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useDebounce } from "@uidotdev/usehooks";
 import { AlertCircle, X } from "lucide-react";
 import Image from "next/image";
 import { useTranslations } from "next-intl";
@@ -59,7 +58,6 @@ export const Line = ({
   const [showMaxQuantityWarning, setShowMaxQuantityWarning] = useState(false);
 
   const t = useTranslations();
-  const inputValue = useDebounce(value, 1000);
 
   const attributeNames = variant.selectionAttributes
     ?.map((attr) => attr.values?.[0]?.name)
@@ -93,32 +91,44 @@ export const Line = ({
     setIsOpen(false);
   };
 
-  useEffect(() => {
-    if (value === quantity.toString()) {
+  const handleInputChange = (nextValue: string) => {
+    setValue(nextValue);
+
+    const qty = Number(nextValue);
+
+    if (nextValue === "" || isNaN(qty) || qty < 1) {
       return;
     }
-    let qty = Number(inputValue);
 
-    if (inputValue === "" || isNaN(qty) || qty < 1) {
-      setValue("1");
-      qty = 1;
+    if (qty > variant.maxQuantity) {
+      setShowMaxQuantityWarning(true);
+
+      return;
+    }
+
+    setShowMaxQuantityWarning(false);
+    void onLineQuantityChange?.(id, qty);
+  };
+
+  const handleInputBlur = () => {
+    const qty = Number(value);
+
+    if (value === "" || isNaN(qty) || qty < 1) {
+      setValue(quantity.toString());
+      setShowMaxQuantityWarning(false);
 
       return;
     }
 
     if (qty > variant.maxQuantity) {
       setValue(variant.maxQuantity.toString());
-      qty = variant.maxQuantity;
-      setShowMaxQuantityWarning(true);
-    } else {
-      setValue(qty.toString());
-      if (qty < variant.maxQuantity) {
-        setShowMaxQuantityWarning(false);
-      }
+      void onLineQuantityChange?.(id, variant.maxQuantity);
     }
+  };
 
-    void onLineQuantityChange?.(id, qty);
-  }, [inputValue]);
+  useEffect(() => {
+    setValue(quantity.toString());
+  }, [quantity]);
 
   return (
     <div className="w-full">
@@ -183,7 +193,8 @@ export const Line = ({
                     type="text"
                     disabled={isDisabled}
                     value={value}
-                    onChange={(evt) => setValue(evt.target.value)}
+                    onChange={(evt) => handleInputChange(evt.target.value)}
+                    onBlur={handleInputBlur}
                     inputMode="numeric"
                     data-testid="cart-product-line-qty"
                     id={`${id}:qty`}


### PR DESCRIPTION
 I want to merge this change because cart mutations currently block the UI on a server round-trip: the cart page shows a spinner and disables the checkout button until Saleor responds and the page revalidates, the PDP "Add to bag" button locks up for the whole request, and the header bag counter only updates after revalidation. This PR makes all three surfaces respond immediately and reconciles against the server afterwards.

<!-- Please mention all relevant issue numbers. -->

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Target `main` from a short-lived change branch and use a Conventional Commit PR title.
- [ ] Test the changes locally to ensure they work as expected.
- [ ] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Verify all four Vercel project statuses: `nimara-docs`, `nimara-ecommerce`,
      `nimara-ecommerce-stripe`, and `nimara-marketplace`.
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [ ] Keep incomplete behavior disabled with a short-lived feature flag or branch-by-abstraction seam.
- [ ] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [ ] Update documentation to reflect any changes in functionality.
