### PR TITLE
fix: scope Stripe gateway customer to its Stripe account

### DIFF
--- a/apps/stripe/src/app/api/saleor/webhooks/payment/payment-method-initialize-tokenization-session/route.ts
+++ b/apps/stripe/src/app/api/saleor/webhooks/payment/payment-method-initialize-tokenization-session/route.ts
@@ -2,6 +2,7 @@ import { type PaymentMethodInitializeTokenizationSessionSubscription } from "@/g
 import { resolveAppConfigForChannel } from "@/lib/saleor/config/context";
 import { tokenizationResponse } from "@/lib/saleor/payment-method/util";
 import { verifySaleorWebhookRoute } from "@/lib/saleor/webhooks/api";
+import { resolveStripeAccountId } from "@/lib/stripe/account";
 import { getStripeApi, stripeRouteErrorsHandler } from "@/lib/stripe/api";
 import { STRIPE_SETUP_USAGE } from "@/lib/stripe/const";
 import { resolveGatewayCustomerId } from "@/lib/stripe/customer";
@@ -29,6 +30,7 @@ export const POST = stripeRouteErrorsHandler(
       const stripe = getStripeApi(gatewayConfig.secretKey);
 
       const customerId = await resolveGatewayCustomerId({
+        accountId: await resolveStripeAccountId({ gatewayConfig, stripe }),
         channelSlug,
         logger,
         saleorClient: getSaleorClient({ authToken, logger, saleorDomain }),

--- a/apps/stripe/src/app/api/saleor/webhooks/payment/stored-payment-method-delete-requested/route.ts
+++ b/apps/stripe/src/app/api/saleor/webhooks/payment/stored-payment-method-delete-requested/route.ts
@@ -5,6 +5,7 @@ import { isError } from "@/lib/error";
 import { resolveAppConfigForChannel } from "@/lib/saleor/config/context";
 import { deleteResponse } from "@/lib/saleor/payment-method/util";
 import { verifySaleorWebhookRoute } from "@/lib/saleor/webhooks/api";
+import { resolveStripeAccountId } from "@/lib/stripe/account";
 import { getStripeApi, stripeRouteErrorsHandler } from "@/lib/stripe/api";
 import { findGatewayCustomerId } from "@/lib/stripe/customer";
 import { getExpandableId } from "@/lib/stripe/payment-method";
@@ -30,6 +31,7 @@ export const POST = stripeRouteErrorsHandler(
       const { gatewayConfig } = config;
       const stripe = getStripeApi(gatewayConfig.secretKey);
       const customerId = findGatewayCustomerId({
+        accountId: await resolveStripeAccountId({ gatewayConfig, stripe }),
         channelSlug,
         user: event.user,
       });

--- a/apps/stripe/src/app/api/saleor/webhooks/payment/stored-payment-method-list/route.ts
+++ b/apps/stripe/src/app/api/saleor/webhooks/payment/stored-payment-method-list/route.ts
@@ -5,6 +5,7 @@ import { isError } from "@/lib/error";
 import { resolveAppConfigForChannel } from "@/lib/saleor/config/context";
 import { listResponse } from "@/lib/saleor/payment-method/util";
 import { verifySaleorWebhookRoute } from "@/lib/saleor/webhooks/api";
+import { resolveStripeAccountId } from "@/lib/stripe/account";
 import { getStripeApi, stripeRouteErrorsHandler } from "@/lib/stripe/api";
 import { findGatewayCustomerId } from "@/lib/stripe/customer";
 import {
@@ -34,6 +35,7 @@ export const POST = stripeRouteErrorsHandler(
       const { gatewayConfig } = config;
       const stripe = getStripeApi(gatewayConfig.secretKey);
       const customerId = findGatewayCustomerId({
+        accountId: await resolveStripeAccountId({ gatewayConfig, stripe }),
         channelSlug,
         user: event.user,
       });

--- a/apps/stripe/src/app/api/saleor/webhooks/payment/transaction-initialize-session/route.ts
+++ b/apps/stripe/src/app/api/saleor/webhooks/payment/transaction-initialize-session/route.ts
@@ -13,6 +13,7 @@ import {
 } from "@/lib/saleor/transaction/schema";
 import { constructTransactionEventResponse } from "@/lib/saleor/transaction/util";
 import { verifySaleorWebhookRoute } from "@/lib/saleor/webhooks/api";
+import { resolveStripeAccountId } from "@/lib/stripe/account";
 import { getStripeApi, stripeRouteErrorsHandler } from "@/lib/stripe/api";
 import { STRIPE_SETUP_USAGE } from "@/lib/stripe/const";
 import { resolveGatewayCustomerId } from "@/lib/stripe/customer";
@@ -89,6 +90,7 @@ export const POST = stripeRouteErrorsHandler(
        */
       if (user) {
         customerId = await resolveGatewayCustomerId({
+          accountId: await resolveStripeAccountId({ gatewayConfig, stripe }),
           channelSlug,
           logger,
           saleorClient: getSaleorClient({ authToken, logger, saleorDomain }),

--- a/apps/stripe/src/app/app/actions/save-data-action.tsx
+++ b/apps/stripe/src/app/app/actions/save-data-action.tsx
@@ -6,6 +6,7 @@ import { isError } from "@/lib/error";
 import { resolveDashboardTenant } from "@/lib/saleor/config/context";
 import { type SaleorAppConfig } from "@/lib/saleor/config/schema";
 import { SaleorDomainNotAllowedError } from "@/lib/saleor/error";
+import { getStripeApi } from "@/lib/stripe/api";
 import { installWebhooks, uninstallWebhooks } from "@/lib/stripe/webhooks/util";
 import { getConfigProvider } from "@/providers/config";
 import { getLoggingProvider } from "@/providers/logging";
@@ -42,18 +43,42 @@ export const saveDataAction = async ({
   const logger = getLoggingProvider();
 
   const storedPaymentGatewayConfig = appConfig?.paymentGatewayConfig ?? {};
-  const updatedPaymentGatewayConfig = Object.entries(data).reduce<
-    SaleorAppConfig["paymentGatewayConfig"]
-  >((acc, [channelSlug, config]) => {
-    acc[channelSlug] = {
+  const updatedPaymentGatewayConfig: SaleorAppConfig["paymentGatewayConfig"] =
+    {};
+
+  /*
+    Read once per key, since channels sharing a key share the account. A key
+    without permission to read it leaves the id out; the webhooks then ask
+    Stripe themselves.
+  */
+  const accountIds = new Map<string, string | undefined>();
+  const resolveAccountId = async (secretKey: string) => {
+    if (!accountIds.has(secretKey)) {
+      try {
+        accountIds.set(
+          secretKey,
+          (await getStripeApi(secretKey).accounts.retrieve()).id,
+        );
+      } catch (err) {
+        logger.warning("Failed to read the Stripe account id.", {
+          errors: isError(err) ? [{ message: err.message }] : [],
+        });
+        accountIds.set(secretKey, undefined);
+      }
+    }
+
+    return accountIds.get(secretKey);
+  };
+
+  for (const [channelSlug, config] of Object.entries(data)) {
+    updatedPaymentGatewayConfig[channelSlug] = {
       ...storedPaymentGatewayConfig[channelSlug],
+      accountId: await resolveAccountId(config.secretKey),
       currency: config.currency,
       secretKey: config.secretKey,
       publicKey: config.publicKey,
     };
-
-    return acc;
-  }, {});
+  }
 
   if (appUrl) {
     // Remove old webhooks in case of configuration change.

--- a/apps/stripe/src/lib/saleor/config/schema.ts
+++ b/apps/stripe/src/lib/saleor/config/schema.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const paymentGatewayConfig = z.record(
   z.string(),
   z.object({
+    accountId: z.string().optional(),
     currency: z.string(),
     publicKey: z.string(),
     secretKey: z.string(),

--- a/apps/stripe/src/lib/saleor/payment-method/const.ts
+++ b/apps/stripe/src/lib/saleor/payment-method/const.ts
@@ -1,9 +1,16 @@
 export const GATEWAY_CUSTOMER_METADATA_NAMESPACE = "stripe.customer";
 
 /**
- * Channel-scoped because each channel may use a different Stripe account.
+ * Scoped to the channel and to the account behind it. A customer id only
+ * exists in the Stripe account that created it, so swapping the account for a
+ * channel must not resolve the mapping made for the previous one.
  */
-export const getGatewayCustomerMetadataKey = (channelSlug: string) =>
-  `${GATEWAY_CUSTOMER_METADATA_NAMESPACE}.${channelSlug}`;
+export const getGatewayCustomerMetadataKey = ({
+  accountId,
+  channelSlug,
+}: {
+  accountId: string;
+  channelSlug: string;
+}) => `${GATEWAY_CUSTOMER_METADATA_NAMESPACE}.${channelSlug}.${accountId}`;
 
 export const TOKENIZED_PAYMENT_FLOW = ["INTERACTIVE"] as const;

--- a/apps/stripe/src/lib/stripe/account.ts
+++ b/apps/stripe/src/lib/stripe/account.ts
@@ -1,0 +1,17 @@
+import { type Stripe } from "stripe";
+
+import { type PaymentGatewayConfig } from "@/lib/saleor/config/schema";
+
+/**
+ * The account id is captured when the channel is configured. A configuration
+ * saved before that, or with a key that may not read the account, asks Stripe
+ * for it instead.
+ */
+export const resolveStripeAccountId = async ({
+  gatewayConfig,
+  stripe,
+}: {
+  gatewayConfig: PaymentGatewayConfig[string];
+  stripe: Stripe;
+}): Promise<string> =>
+  gatewayConfig.accountId ?? (await stripe.accounts.retrieve()).id;

--- a/apps/stripe/src/lib/stripe/customer.test.ts
+++ b/apps/stripe/src/lib/stripe/customer.test.ts
@@ -13,7 +13,8 @@ import {
 const CHANNEL_SLUG = "default-channel";
 const SALEOR_DOMAIN = "shop.saleor.cloud";
 const ENVIRONMENT = "production";
-const METADATA_KEY = `stripe.customer.${CHANNEL_SLUG}`;
+const ACCOUNT_ID = "acct_123";
+const METADATA_KEY = `stripe.customer.${CHANNEL_SLUG}.${ACCOUNT_ID}`;
 const USER_ID = "VXNlcjox";
 
 const buildUser = ({
@@ -67,7 +68,11 @@ describe("customer", () => {
 
   describe("findGatewayCustomerId", () => {
     const find = (user: SaleorWebhookUser) =>
-      findGatewayCustomerId({ channelSlug: CHANNEL_SLUG, user });
+      findGatewayCustomerId({
+        accountId: ACCOUNT_ID,
+        channelSlug: CHANNEL_SLUG,
+        user,
+      });
 
     it("should return the customer the app owns", () => {
       // given
@@ -87,6 +92,24 @@ describe("customer", () => {
       const user = buildUser({
         privateMetadata: [
           { key: "stripe.customer.other-channel", value: "cus_other" },
+        ],
+      });
+
+      // when
+      const result = find(user);
+
+      // then
+      expect(result).toBeNull();
+    });
+
+    it("should ignore a mapping made for another Stripe account", () => {
+      // given
+      const user = buildUser({
+        privateMetadata: [
+          {
+            key: `stripe.customer.${CHANNEL_SLUG}.acct_previous`,
+            value: "cus_previous",
+          },
         ],
       });
 
@@ -131,6 +154,7 @@ describe("customer", () => {
       saleorClient: ReturnType<typeof buildSaleorClient>,
     ) =>
       resolveGatewayCustomerId({
+        accountId: ACCOUNT_ID,
         channelSlug: CHANNEL_SLUG,
         logger: buildLogger(),
         saleorClient,
@@ -154,6 +178,36 @@ describe("customer", () => {
       expect(result).toBe("cus_owned");
       expect(stripe.customers.create).not.toHaveBeenCalled();
       expect(saleorClient.execute).not.toHaveBeenCalled();
+    });
+
+    /**
+     * A customer created in a different Stripe account no longer exists for
+     * the key in use, so reusing its id would fail every payment.
+     */
+    it("should create a customer when the mapping belongs to another account", async () => {
+      // given
+      const stripe = buildStripe();
+      const saleorClient = buildSaleorClient();
+      const user = buildUser({
+        privateMetadata: [
+          {
+            key: `stripe.customer.${CHANNEL_SLUG}.acct_previous`,
+            value: "cus_previous",
+          },
+        ],
+      });
+
+      // when
+      const result = await resolve(user, stripe, saleorClient);
+
+      // then
+      expect(result).toBe("cus_created");
+      expect(saleorClient.execute).toHaveBeenCalledWith(expect.anything(), {
+        variables: {
+          id: USER_ID,
+          input: [{ key: METADATA_KEY, value: "cus_created" }],
+        },
+      });
     });
 
     /**

--- a/apps/stripe/src/lib/stripe/customer.ts
+++ b/apps/stripe/src/lib/stripe/customer.ts
@@ -23,25 +23,29 @@ export type SaleorWebhookUser = {
 };
 
 type CustomerResolveOpts = {
+  accountId: string;
   channelSlug: string;
   user: SaleorWebhookUser;
 };
 
 export const findGatewayCustomerId = ({
+  accountId,
   channelSlug,
   user,
 }: CustomerResolveOpts): string | null =>
   serializeMetadataItems(user.privateMetadata)[
-    getGatewayCustomerMetadataKey(channelSlug)
+    getGatewayCustomerMetadataKey({ accountId, channelSlug })
   ] ?? null;
 
 const persistCustomerId = async ({
+  accountId,
   channelSlug,
   customerId,
   logger,
   saleorClient,
   userId,
 }: {
+  accountId: string;
   channelSlug: string;
   customerId: string;
   logger: Logger;
@@ -55,7 +59,7 @@ const persistCustomerId = async ({
         id: userId,
         input: [
           {
-            key: getGatewayCustomerMetadataKey(channelSlug),
+            key: getGatewayCustomerMetadataKey({ accountId, channelSlug }),
             value: customerId,
           },
         ],
@@ -76,6 +80,7 @@ const persistCustomerId = async ({
 };
 
 export const resolveGatewayCustomerId = async ({
+  accountId,
   channelSlug,
   logger,
   saleorClient,
@@ -88,7 +93,11 @@ export const resolveGatewayCustomerId = async ({
   saleorDomain: string;
   stripe: Stripe;
 }): Promise<string> => {
-  const ownedCustomerId = findGatewayCustomerId({ channelSlug, user });
+  const ownedCustomerId = findGatewayCustomerId({
+    accountId,
+    channelSlug,
+    user,
+  });
 
   if (ownedCustomerId) {
     return ownedCustomerId;
@@ -110,6 +119,7 @@ export const resolveGatewayCustomerId = async ({
   );
 
   await persistCustomerId({
+    accountId,
     channelSlug,
     customerId: customer.id,
     logger,


### PR DESCRIPTION
## Problem

A signed-in shopper could not pay. The Stripe app answered:

```
StripeInvalidRequestError code=resource_missing param=customer statusCode=400
No such customer: 'cus_Uy3aJK5AO5Ivja'
```

and the storefront reported a failed payment, because Saleor turns a failed sync webhook delivery into a transaction event: `message: 'Failed to delivery request.', type: 'CHARGE_FAILURE'`.

The gateway customer is stored on the Saleor user's private metadata under `stripe.customer.<channelSlug>` — keyed by channel alone. A Stripe customer id exists only in the account that created it, so pointing a channel at a different Stripe account (or at the other of test and live) leaves a dead id behind. `resolveGatewayCustomerId` returned it without verifying, so every payment for that shopper failed from then on. `stored-payment-method-list` already degrades gracefully here; the payment path did not.

## Change

- Key the mapping by channel **and** account: `stripe.customer.<channelSlug>.<accountId>`. A mapping made under a previous account no longer resolves, so a fresh customer is created instead of failing.
- Capture the account id when the channel is configured — one `accounts.retrieve()` per distinct secret key, shared by the channels using it. A key without permission to read the account leaves the id out rather than blocking the save.
- `resolveStripeAccountId` reads the id from the configuration, falling back to Stripe for configurations saved before this change, so nothing breaks until the configuration is next saved.

No migration: old unsuffixed metadata entries are simply left unread.

## Out of scope

A customer deleted inside the account currently in use still fails the payment path — account scoping cannot cover that. It needs a `resource_missing` catch-and-recreate at intent creation.

## Tests

`pnpm --filter stripe test` — 177 passed, including two new cases: a mapping from another account is ignored, and a new customer is created rather than reusing the dead id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MS-1241]: https://mirumee.atlassian.net/browse/MS-1241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ