### PR TITLE
fix: require current password in change password form

### DIFF
--- a/apps/storefront/src/app/[locale]/(main)/account/profile/_forms/schema.ts
+++ b/apps/storefront/src/app/[locale]/(main)/account/profile/_forms/schema.ts
@@ -35,7 +35,10 @@ export const updateEmailFormSchema = ({ t }: { t: GetTranslations }) =>
 export const updatePasswordFormSchema = ({ t }: { t: GetTranslations }) =>
   z
     .object({
-      oldPassword: z.string().trim(),
+      oldPassword: z
+        .string()
+        .min(1, { message: t("form-validation.required") })
+        .trim(),
       newPassword: z
         .string()
         .min(MIN_PASSWORD_LENGTH, {

--- a/apps/storefront/src/app/[locale]/(main)/account/profile/_forms/update-password-form.tsx
+++ b/apps/storefront/src/app/[locale]/(main)/account/profile/_forms/update-password-form.tsx
@@ -30,6 +30,7 @@ export function UpdatePasswordForm({
     defaultValues: {
       confirm: "",
       newPassword: "",
+      oldPassword: "",
     },
   });
   const formError = form.formState.errors?.root;


### PR DESCRIPTION
I want to merge this change because leaving the current password field empty on /account/profile currently produces an unhandled error instead of validation feedback — the empty value passes client validation, reaches Saleor, and the rejected mutation surfaces as a generic failure with nothing under the field. This change makes oldPassword a required field in the form schema (and seeds it in defaultValues), so the user sees "Required field" under current password and the request is never sent. It's a two-line, low-risk fix scoped to one form, it uses the same form-validation.required message as every other required field in the storefront, and it resolves NIM-40.

<!-- Please mention all relevant issue numbers. -->

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Target `main` from a short-lived change branch and use a Conventional Commit PR title.
- [ ] Test the changes locally to ensure they work as expected.
- [ ] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Verify all four Vercel project statuses: `nimara-docs`, `nimara-ecommerce`,
      `nimara-ecommerce-stripe`, and `nimara-marketplace`.
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [ ] Keep incomplete behavior disabled with a short-lived feature flag or branch-by-abstraction seam.
- [ ] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [ ] Update documentation to reflect any changes in functionality.
