### PR TITLE
fix: link menu categories to the category page instead of search

### DIFF
--- a/packages/infrastructure/src/cms-menu/dummy/fixtures/sample-menus.ts
+++ b/packages/infrastructure/src/cms-menu/dummy/fixtures/sample-menus.ts
@@ -7,24 +7,24 @@ export const SAMPLE_MENUS: Record<"navbar" | "footer", Menu> = {
       {
         id: "dummy-nav-apparel",
         label: "Apparel",
-        url: "/search?category=apparel",
+        url: "/categories/apparel",
         children: [
           {
             id: "dummy-nav-tees",
             label: "Tees",
-            url: "/search?category=apparel",
+            url: "/categories/apparel",
           },
           {
             id: "dummy-nav-hoodies",
             label: "Hoodies",
-            url: "/search?category=apparel",
+            url: "/categories/apparel",
           },
         ],
       },
       {
         id: "dummy-nav-accessories",
         label: "Accessories",
-        url: "/search?category=accessories",
+        url: "/categories/accessories",
       },
     ],
   },

--- a/packages/infrastructure/src/lib/serializers/cms-menu.ts
+++ b/packages/infrastructure/src/lib/serializers/cms-menu.ts
@@ -19,17 +19,16 @@ const createMenuItemUrl = (
   if (page?.slug) {
     return `/page/${page.slug}`;
   }
-  const queryParams = new URLSearchParams();
-
-  if (category?.slug) {
-    queryParams.append("category", category.slug);
-  }
 
   if (collection?.slug) {
     return `/collections/${collection.slug}`;
   }
 
-  return `/search?${queryParams.toString()}`;
+  if (category?.slug) {
+    return `/categories/${category.slug}`;
+  }
+
+  return "/search";
 };
 
 const serializeSaleorMenuItemChild = (


### PR DESCRIPTION
I want to merge this change because the header and footer navigation still send category menu items to /search?category <slug>, a route that predates the dedicated category page and no longer reflects how we model categories.

<!-- Please mention all relevant issue numbers. -->

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Target `main` from a short-lived change branch and use a Conventional Commit PR title.
- [ ] Test the changes locally to ensure they work as expected.
- [ ] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Verify all four Vercel project statuses: `nimara-docs`, `nimara-ecommerce`,
      `nimara-ecommerce-stripe`, and `nimara-marketplace`.
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [ ] Keep incomplete behavior disabled with a short-lived feature flag or branch-by-abstraction seam.
- [ ] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [ ] Update documentation to reflect any changes in functionality.
