### PR TITLE
fix: show "required" on empty fields and correct password wording

### DIFF
--- a/apps/storefront/src/app/[locale]/(auth)/create-account/schema.ts
+++ b/apps/storefront/src/app/[locale]/(auth)/create-account/schema.ts
@@ -17,8 +17,8 @@ export const formSchema = ({ t }: { t: GetTranslations }) =>
         .trim(),
       email: z
         .string()
+        .min(1, { message: t("form-validation.required") })
         .email({ message: t("form-validation.invalid-email") })
-        .min(1, { message: t("form-validation.email-required") })
         .trim(),
       password: z
         .string()
@@ -28,7 +28,10 @@ export const formSchema = ({ t }: { t: GetTranslations }) =>
           }),
         })
         .trim(),
-      confirm: z.string().trim(),
+      confirm: z
+        .string()
+        .min(1, { message: t("form-validation.required") })
+        .trim(),
     })
     .refine((data) => data.password === data.confirm, {
       message: t("form-validation.passwords-dont-match"),

--- a/apps/storefront/src/app/[locale]/(main)/account/profile/_forms/schema.ts
+++ b/apps/storefront/src/app/[locale]/(main)/account/profile/_forms/schema.ts
@@ -20,6 +20,7 @@ export const updateEmailFormSchema = ({ t }: { t: GetTranslations }) =>
   z.object({
     email: z
       .string()
+      .min(1, { message: t("form-validation.required") })
       .email({ message: t("form-validation.invalid-email") })
       .trim(),
     password: z
@@ -47,7 +48,10 @@ export const updatePasswordFormSchema = ({ t }: { t: GetTranslations }) =>
           }),
         })
         .trim(),
-      confirm: z.string().trim(),
+      confirm: z
+        .string()
+        .min(1, { message: t("form-validation.required") })
+        .trim(),
     })
     .refine((data) => data.newPassword === data.confirm, {
       message: t("form-validation.passwords-dont-match"),

--- a/apps/storefront/src/foundation/checkout/sections/user-details/schema.ts
+++ b/apps/storefront/src/foundation/checkout/sections/user-details/schema.ts
@@ -6,8 +6,8 @@ export const userDetailsEmailFormSchema = ({ t }: { t: GetTranslations }) =>
   z.object({
     email: z
       .string()
-      .email({ message: t("form-validation.invalid-email") })
       .min(1, { message: t("form-validation.required") })
+      .email({ message: t("form-validation.invalid-email") })
       .trim(),
   });
 

--- a/packages/i18n/src/messages/en/common.json
+++ b/packages/i18n/src/messages/en/common.json
@@ -251,10 +251,9 @@
   "form-validation": {
     "Invalid email": "Invalid email",
     "Invalid value": "Invalid value",
-    "email-required": "Email is required to create an account.",
     "enter-discount-code": "Type the discount code first",
     "invalid-email": "Oops, wrong email address.",
-    "min-length-password": "Password should contain at least {minimum} signs.",
+    "min-length-password": "Password should contain at least {minimum} characters.",
     "oldPassword": "Wrong password",
     "passwords-dont-match": "The entered passwords don't match.",
     "required": "Required field",

--- a/packages/i18n/src/messages/en/storefront.json
+++ b/packages/i18n/src/messages/en/storefront.json
@@ -89,7 +89,7 @@
     "log-out": "Log out",
     "new-password": "New password",
     "or-continue-as-guest": "Or continue as a guest",
-    "password-placeholder": "At least {minPasswordLength} signs, digits allowed",
+    "password-placeholder": "At least {minPasswordLength} characters, digits allowed",
     "password-reset": "Reset password",
     "reset-password": "Password reset",
     "reset-password-description": "Please type the email address used to create the account you'd like to access.",


### PR DESCRIPTION
I want to merge this change because empty email fields reported "invalid email" because zod ran .email() before .min(1). Reorder so blank input yields "Required field" on create-account, guest checkout, and the profile email form, and add the same rule to the create-account and profile password confirmation fields.

Replace "signs" with "characters" in the minimum-password-length message and its placeholder, and drop the now-unused email-required key in favour of the shared required message.

<!-- Please mention all relevant issue numbers. -->

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Target `main` from a short-lived change branch and use a Conventional Commit PR title.
- [ ] Test the changes locally to ensure they work as expected.
- [ ] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Verify all four Vercel project statuses: `nimara-docs`, `nimara-ecommerce`,
      `nimara-ecommerce-stripe`, and `nimara-marketplace`.
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [ ] Keep incomplete behavior disabled with a short-lived feature flag or branch-by-abstraction seam.
- [ ] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [ ] Update documentation to reflect any changes in functionality.
