### PR TITLE
docs(llm-wiki): add QA test-case/plan formats and exploratory-session skill

### DIFF
--- a/.agents/skills/exploratory-session/SKILL.md
+++ b/.agents/skills/exploratory-session/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: exploratory-session
+description: Run an evidence-first exploratory testing session against a newly shipped feature by driving the real Nimara storefront through the Playwright MCP, then write a session report an operator can act on. Use this skill whenever the user asks to explore a new feature on a test environment, run an exploratory/PLAYWRIGHT-MCP session, "test the new feature end to end before we write cases", or produce a session report for a feature just deployed. This is the first step of the new-feature flow; it precedes test-case design (use test-case-design) and E2E authoring. Do NOT use to retest a specific reported bug (use bug-retest-triage) or for a broad regression pass across an existing surface (use regression-sweep).
+---
+
+# Exploratory Session (Playwright MCP)
+
+Explore a freshly shipped feature by driving the **real** application through the Playwright
+MCP, discover how it actually behaves, and hand the operator an evidence-backed **session
+report** — the input to test-case design and E2E authoring. Never fabricate behaviour, never
+force a verdict. This is the AI half of the new-feature flow; the operator decides what happens
+to the report.
+
+## What the Playwright MCP is here
+
+The Playwright MCP is the agent's hands and eyes on the running app: it navigates, reads the
+page (accessibility tree / DOM, selectors), clicks, types, captures screenshots, and reads
+console and network. It is a **harness for observation**, not a verdict engine — the same
+evidence-only discipline as [[Bug Retest & Triage Process]] applies. The committed Playwright
+E2E suite in `apps/automated-tests` is where confirmed behaviour is later encoded; this skill is
+the exploratory pass that comes first.
+
+## Operating principles
+
+1. **Evidence only.** Every claim in the report is backed by an artifact (screenshot,
+   DOM/selector capture, network response, measurement). "Looked fine" is not a finding — see
+   [[Verdict & Evidence Policy]].
+2. **Never fabricate.** Missing PRD detail, env URL, credentials, or test data = STOP and ASK,
+   never guess or invent inputs.
+3. **Right environment.** Test the deployed feature on the correct storefront and channel
+   (`/` = US, `/gb` = GB), not the marketing site — see [[Environments & Access Matrix]].
+4. **Cheapest reliable method.** Use the browser for what only the browser shows; drop to
+   source/route/response inspection when it observes the behaviour more directly — see
+   [[Test Method Playbooks]].
+5. **Explore classes, not clicks.** Seed exploration from personas and the behaviour-driving
+   axes ([[Coverage Maps]]), so the session covers the space rather than one happy path.
+6. **No blocking dialogs.** Do not trigger native `alert`/`confirm`/`prompt`; they freeze the
+   MCP. Read the console instead of alerting.
+7. **Report, don't decide.** The session output is a report for the operator; it does not close
+   tickets or approve the feature.
+
+## Before you start
+
+Confirm the inputs in [[Exploratory Session Inputs]] are present: the PRD (acceptance criteria,
+scope, personas, risks), the feature is deployed to a reachable env, and the data/accounts the
+journeys need exist. Anything missing is a stop-and-ask. Read [[Environments & Access Matrix]]
+for the env/channel and credentials.
+
+## Workflow
+
+1. **UNDERSTAND** — read the PRD: acceptance criteria, scope/out-of-scope, personas, risks.
+   State in your own words what the feature should do and what "correct" looks like as
+   observable behaviour. Gaps in acceptance criteria = ASK trigger.
+2. **PLAN** — write a lightweight plan to `qa/investigation/<feature>.md`: env URL + channel,
+   accounts/data, the persona journeys to walk, and the behaviour-driving axes to probe
+   (country, auth, payment outcome, field state) from [[Coverage Maps]].
+3. **CHECK PREREQS — ASK IF BLOCKED.** Verify env reachable, credentials work, and the specific
+   data exists before opening the browser. Missing/ambiguous → STOP and ASK, listing exactly
+   what you need. Never fabricate.
+4. **EXPLORE (Playwright MCP)** — walk each journey on the real app. At each meaningful step:
+   read the page (accessibility tree / DOM, the role/label/test-id selectors the page objects
+   in `apps/automated-tests/pages` already use), act, and observe. Capture the **application
+   context** (URL, key selectors, DOM state) and decisive **screenshots**, plus console/network
+   where the contract crosses them. Run a **control** for anything ambiguous or flaky
+   ([[Known Flaky, Blocked & Backend-Only]]). Store artifacts under
+   `qa/investigation/screenshots/<feature>/`.
+5. **WRITE THE SESSION REPORT** — `qa/investigation/<feature>-session.md`: what was explored
+   (journeys × axes), what was observed vs. the PRD's expected behaviour, discrepancies and
+   suspected defects (generalised to classes, classified per [[Defect Taxonomy & Severity]]),
+   the application context (selectors/DOM worth reusing for E2E), and explicit coverage gaps /
+   anything blocked. Link every claim to its artifact.
+6. **GUARD AGAINST HALLUCINATION.** Before handing off, re-check each finding against its
+   artifact. A finding with no artifact is not a finding — drop it or re-observe. Flag anything
+   you could not directly observe as requiring service-level or operator verification.
+7. **HANDOFF** — report to the operator. On approval, the flow continues: derive a covering set
+   with **test-case-design** ([Test Case](../../llm-wiki/_templates/TestCase.md) format), then
+   encode confirmed behaviour as E2E specs in `apps/automated-tests`. This skill stops at the
+   report.
+
+## Output artifacts
+
+- `qa/investigation/<feature>.md` — the session plan.
+- `qa/investigation/screenshots/<feature>/` — evidence.
+- `qa/investigation/<feature>-session.md` — the session report (the deliverable).
+
+## References
+
+[[Exploratory Session Inputs]] · [[Environments & Access Matrix]] · [[Coverage Maps]] · [[Test Method Playbooks]] · [[Test Data & Fixtures]] · [[Verdict & Evidence Policy]] · [[Defect Taxonomy & Severity]] · [[Known Flaky, Blocked & Backend-Only]] · [[Bug Retest & Triage Process]]

--- a/llm-wiki/_templates/TestCase.md
+++ b/llm-wiki/_templates/TestCase.md
@@ -1,0 +1,82 @@
+---
+type: "Template"
+title: "Test Case Template"
+description: "Reusable format for a single QA test case: one behaviour class, one representative, one evidence-backed verdict."
+tags:
+  - "template"
+  - "qa"
+  - "test-case"
+created: "2026-08-10T08:28:14+00:00"
+# A generic template (no `template_for`): test cases are QA work-products, not durable
+# llm-wiki records. Instances are written by the `test-case-design` skill under
+# `qa/triage/plans/<NAME>-tests.md` and their evidence under `qa/triage/evidence/<NAME>/`.
+# This file is the format contract those instances follow. Keep the format here; keep the
+# instances out of the wiki tree.
+---
+
+## Content
+
+One test case covers exactly one **behaviour class** — the smallest set of inputs that all
+behave the same — with one representative and, where the class has edges, its boundary and
+negative neighbours. Derive classes by equivalence partitioning against a source of truth,
+never from ad-hoc examples. See [Coverage Maps](../quality/Coverage%20Maps.md).
+
+A set of these is complete only when every class is either covered or explicitly skipped with
+a reason — no silent gaps.
+
+### Identity
+
+- **ID:** `TC-<feature>-<NN>` — stable within the plan it belongs to.
+- **Title:** the behaviour under test, in one line.
+- **Requirement / source of truth:** link the PRD, spec, or data source the class derives
+  from (e.g. `google-i18n-address all.json`, a PRD acceptance criterion).
+- **Behaviour class:** the partition this case represents, and why one representative covers
+  the whole class.
+
+### Preconditions
+
+- **Environment & channel:** exact env URL and channel prefix — see
+  [Environments & Access Matrix](../quality/Environments%20%26%20Access%20Matrix.md).
+- **Account / auth state:** guest, logged-in, role.
+- **Data & fixtures:** the specific verified data used — see
+  [Test Data & Fixtures](../quality/Test%20Data%20%26%20Fixtures.md). Never fabricate; if data
+  is missing, stop and ask.
+- **App / cart state:** any starting state the case assumes.
+
+### Steps
+
+1. …
+2. …
+
+### Expected result
+
+What must be observed for a pass — stated as a checkable assertion, not a vague expectation.
+Include the expected failure path where the class has one.
+
+### Method
+
+The cheapest reliable technique that directly observes this behaviour (source inspection,
+unit, route, browser, geometry, response capture, …) and its limitations. See
+[Test Method Playbooks](../quality/Test%20Method%20Playbooks.md).
+
+### Result
+
+- **Verdict:** pass / fail / blocked — on evidence only; "couldn't make it fail" ≠ pass. See
+  [Verdict & Evidence Policy](../quality/Verdict%20%26%20Evidence%20Policy.md).
+- **Evidence:** path under `qa/triage/evidence/<NAME>/` (screenshot, measurement, response
+  capture) plus the exact env/build/SHA observed.
+- **Notes / caveats:** flakiness, control run, method limits — see
+  [Known Flaky, Blocked & Backend-Only](../quality/Known%20Flaky%2C%20Blocked%20%26%20Backend-Only.md).
+
+### On failure
+
+Generalise the failure to its **class**, then classify and file per
+[Defect Taxonomy & Severity](../quality/Defect%20Taxonomy%20%26%20Severity.md).
+
+## Related Notes
+
+[Quality & Testing (MOC)](../quality/Quality%20%26%20Testing%20%28MOC%29.md)
+[Coverage Maps](../quality/Coverage%20Maps.md)
+[Test Data & Fixtures](../quality/Test%20Data%20%26%20Fixtures.md)
+[Test Method Playbooks](../quality/Test%20Method%20Playbooks.md)
+[Verdict & Evidence Policy](../quality/Verdict%20%26%20Evidence%20Policy.md)

--- a/llm-wiki/_templates/TestPlan.md
+++ b/llm-wiki/_templates/TestPlan.md
@@ -1,0 +1,75 @@
+---
+type: "Template"
+title: "Test Plan Template"
+description: "Reusable format for a test plan: the surface, the axes to cover, the approach per axis, and what would block or stop the effort."
+tags:
+  - "template"
+  - "qa"
+  - "test-plan"
+created: "2026-08-10T08:28:14+00:00"
+# A generic template (no `template_for`): a test plan is a QA work-product, not a durable
+# llm-wiki record. Instances are written under `qa/test-plan/<NAME>.md` (or
+# `qa/triage/plans/`) and drive `test-case-design` / `regression-sweep`. This file is the
+# format contract; keep the instances out of the wiki tree.
+---
+
+## Content
+
+A test plan states **what will be covered and how** before any browser opens, so coverage is
+a decision rather than an accident. It sits above test cases: the plan enumerates the axes
+and the approach; the cases cover the classes within them. Keep it short — a plan nobody reads
+before executing is waste.
+
+### Scope
+
+- **Feature / surface under test:** what this plan covers, in one line.
+- **Requirement / source of truth:** link the PRD, spec, or coverage map this plan derives
+  from — see [Coverage Maps](../quality/Coverage%20Maps.md).
+- **In scope / out of scope:** name what is deliberately excluded and why (fast-follow,
+  backend-only, separate plan).
+
+### Coverage axes
+
+The variables that change behaviour, and the representatives swept per axis — e.g.
+page type × channel (`/` US, `/gb` GB) × device × auth state × payment outcome. Partition,
+don't enumerate: cover each class, not every input.
+
+| Axis | Values / representatives | Why it matters |
+| --- | --- | --- |
+| … | … | … |
+
+### Approach per axis
+
+The cheapest reliable method for each signal — curl+grep for SEO/structural, Lighthouse for
+perf, Playwright for interactive flows, response listeners for contracts. See
+[Test Method Playbooks](../quality/Test%20Method%20Playbooks.md). Note which axes become
+individual test cases ([Test Case](TestCase.md)) and which are a broad sweep.
+
+### Environments & data
+
+- **Environments / channels:** exact URLs and channel prefixes — see
+  [Environments & Access Matrix](../quality/Environments%20%26%20Access%20Matrix.md).
+- **Accounts & fixtures:** the verified data and accounts needed — see
+  [Test Data & Fixtures](../quality/Test%20Data%20%26%20Fixtures.md). List what is missing;
+  never fabricate.
+
+### Entry & exit criteria
+
+- **Entry:** what must be true to start (feature deployed to the target env, PRD reviewed,
+  data available).
+- **Exit / done:** every axis covered or explicitly skipped with a reason; verdicts backed by
+  evidence per [Verdict & Evidence Policy](../quality/Verdict%20%26%20Evidence%20Policy.md).
+- **Kill / block criteria:** what makes the effort stop and ask — missing env, missing data,
+  a blocking defect — see [Known Flaky, Blocked & Backend-Only](../quality/Known%20Flaky%2C%20Blocked%20%26%20Backend-Only.md).
+
+### Risks & known gaps
+
+- R-1: risk — how it is handled or accepted.
+
+## Related Notes
+
+[Quality & Testing (MOC)](../quality/Quality%20%26%20Testing%20%28MOC%29.md)
+[Coverage Maps](../quality/Coverage%20Maps.md)
+[Test Method Playbooks](../quality/Test%20Method%20Playbooks.md)
+[Environments & Access Matrix](../quality/Environments%20%26%20Access%20Matrix.md)
+[Verdict & Evidence Policy](../quality/Verdict%20%26%20Evidence%20Policy.md)

--- a/llm-wiki/index.md
+++ b/llm-wiki/index.md
@@ -19,6 +19,8 @@ okf_version: "0.1"
 - [RFC Design Doc Template](_templates/RFC.md) - Reusable template for an RFC design proposal: problem, requirements, proposed solution, and cross-cutting considerations.
 - [Undefined Template](_templates/Undefined.md) - Generic template for a new concept document.
 - [Saleor Schema Note Template](_templates/saleor-schema-note.md) - Reusable template for a version-stamped Saleor GraphQL schema note.
+- [Test Case Template](_templates/TestCase.md) - Reusable format for a single QA test case: one behaviour class, one representative, one evidence-backed verdict.
+- [Test Plan Template](_templates/TestPlan.md) - Reusable format for a test plan: the surface, the axes to cover, the approach per axis, and what would block or stop the effort.
 
 # Sources
 
@@ -109,6 +111,7 @@ okf_version: "0.1"
 - [Test Method Playbooks](quality/Test%20Method%20Playbooks.md) - Cheapest reliable verification technique by defect class.
 - [Verdict & Evidence Policy](quality/Verdict%20%26%20Evidence%20Policy.md) - Evidence rules for defensible QA verdicts.
 - [Known Flaky, Blocked & Backend-Only](quality/Known%20Flaky%2C%20Blocked%20%26%20Backend-Only.md) - Areas where agents should not force a verdict.
+- [Exploratory Session Inputs](quality/Exploratory%20Session%20Inputs.md) - What an AI-driven exploratory testing session needs as input for a new feature, and how much of it the current PRD template already supplies.
 
 # Operations
 

--- a/llm-wiki/log.md
+++ b/llm-wiki/log.md
@@ -457,3 +457,18 @@
 - **Gap**: The orphaned-PaymentIntent concern in NIM-51 is narrowed, not closed. A complete checkout
   still opens a fresh intent on every mount and remount of the payment element. Recorded as a
   deviation in IMP-0004; no separate work item exists for it.
+
+## 2026-08-10
+
+- **Create**: Added the QA work-product templates `_templates/TestCase.md` and
+  `_templates/TestPlan.md` (generic templates, no record contract) and the QA note
+  `quality/Exploratory Session Inputs.md`. Registered all three in `index.md`.
+- **Create**: Added the `.agents/skills/exploratory-session` runbook — drive a newly shipped
+  feature through the Playwright MCP and produce an evidence-backed session report, the first
+  step of the new-feature flow.
+- **Update**: Reconciled the Skills list in `quality/Quality & Testing (MOC).md` to name every
+  real QA runbook under `.agents/skills/` (exploratory-session, test-case-design,
+  regression-sweep, bug-retest-triage) and linked the new formats and exploratory-session
+  inputs note. Sourced from the QA process board (mirumee/nimara llm-wiki/quality) dated
+  2026-08-10.
+- **Lint**: `wiki:lint` at zero violations across 96 files.

--- a/llm-wiki/quality/Exploratory Session Inputs.md
+++ b/llm-wiki/quality/Exploratory Session Inputs.md
@@ -1,0 +1,71 @@
+---
+type: "QA Note"
+title: "Exploratory Session Inputs"
+description: "What an AI-driven exploratory testing session needs as input for a new feature, and how much of it the current PRD template already supplies."
+tags:
+  - "qa"
+  - "exploratory"
+  - "prd"
+  - "readiness"
+  - "agents"
+created: "2026-08-10T08:28:14+00:00"
+---
+
+## Content
+
+The new-feature flow starts an **exploratory session** the moment a feature reaches a test
+environment. An agent can only explore usefully if the inputs below are present. This note is
+the checklist the [exploratory-session skill](Quality%20%26%20Testing%20%28MOC%29.md) reads,
+and the readiness bar a PRD must clear before it triggers a session.
+
+### Required inputs
+
+1. **What "correct" means** — the feature's acceptance criteria and user stories, concrete
+   enough to turn into a pass/fail observation. Without them a session produces description,
+   not verdicts.
+2. **Scope boundaries** — what is in and out of this release, so the agent explores the shipped
+   slice and does not file out-of-scope behaviour as defects.
+3. **Personas & primary journeys** — who the feature is for and the paths they take, to seed
+   exploration instead of random clicking.
+4. **Environment & channel** — where the feature is deployed and under which channel — see
+   [Environments & Access Matrix](Environments%20%26%20Access%20Matrix.md).
+5. **Data & fixtures** — the accounts, cards, and addresses the journeys need — see
+   [Test Data & Fixtures](Test%20Data%20%26%20Fixtures.md). Missing data is a stop-and-ask, never
+   a fabrication.
+6. **Behaviour-driving variables** — the axes that partition behaviour (country, auth, payment
+   outcome, field state), so exploration covers classes — see
+   [Coverage Maps](Coverage%20Maps.md).
+7. **Known risks & open questions** — where the feature is expected to be fragile, to focus
+   the session.
+
+### PRD template coverage (readiness review)
+
+Reviewed against `_templates/PRD.md`. The PRD is the primary input to the session, so its
+format has to carry most of the above.
+
+| Required input | PRD field that supplies it | Status |
+| --- | --- | --- |
+| What "correct" means | `Acceptance Criteria`, `User Stories` | **Covered** |
+| Scope boundaries | `Scope`, `Out of Scope` | **Covered** |
+| Personas & journeys | `personas` frontmatter, `User Stories` | **Covered** |
+| Behaviour-driving variables | — (implicit in ACs) | **Partial** — not enumerated as axes; the session must derive them from [Coverage Maps](Coverage%20Maps.md). |
+| Known risks / open questions | `Risks`, `Open Questions` | **Covered** |
+| Environment & channel | — | **Gap** — a PRD is env-agnostic. Comes from [Environments & Access Matrix](Environments%20%26%20Access%20Matrix.md) + the deploy, not the PRD. |
+| Data & fixtures | — | **Gap** — comes from [Test Data & Fixtures](Test%20Data%20%26%20Fixtures.md), not the PRD. |
+
+**Conclusion.** The current PRD format supplies what defines *correctness* (acceptance
+criteria, scope, personas, risks) and is sufficient to start a session. The two gaps —
+environment/channel and concrete test data — are correctly owned by QA notes, not the PRD;
+the session composes the PRD with those notes rather than expecting the PRD to duplicate them.
+The one soft spot inside the PRD is that behaviour-driving variables are implicit in the
+acceptance criteria; the session derives explicit equivalence classes from
+[Coverage Maps](Coverage%20Maps.md) rather than reading them off the PRD. No PRD-template
+change is required to unblock the flow.
+
+## Related Notes
+
+[Quality & Testing (MOC)](Quality%20%26%20Testing%20%28MOC%29.md)
+[Coverage Maps](Coverage%20Maps.md)
+[Environments & Access Matrix](Environments%20%26%20Access%20Matrix.md)
+[Test Data & Fixtures](Test%20Data%20%26%20Fixtures.md)
+[Verdict & Evidence Policy](Verdict%20%26%20Evidence%20Policy.md)

--- a/llm-wiki/quality/Quality & Testing (MOC).md
+++ b/llm-wiki/quality/Quality & Testing (MOC).md
@@ -34,6 +34,15 @@ Knowledge lives in these notes; executable runbooks live under `.agents/skills/`
 - [Test Method Playbooks](Test%20Method%20Playbooks.md) — for bug class X, use technique Y (throttling, response inspection, geometry, Lighthouse, code inspection…).
 - [Test Data & Fixtures](Test%20Data%20%26%20Fixtures.md) — Stripe cards, addresses, postcodes, known products, i18n address rules.
 - [Coverage Maps](Coverage%20Maps.md) — equivalence partitions so you test _classes_, not random cases.
+- [Exploratory Session Inputs](Exploratory%20Session%20Inputs.md) — what an AI exploratory session needs from the PRD and QA notes before a new feature is explored.
+
+### Formats (work-product templates)
+
+Test cases and test plans are QA work-products written under `qa/`, not wiki records. Their
+format lives in `_templates/`:
+
+- [Test Case Template](../_templates/TestCase.md) — one behaviour class, one representative, one evidence-backed verdict.
+- [Test Plan Template](../_templates/TestPlan.md) — the surface, the axes to cover, the approach per axis, and what blocks the effort.
 
 ### Discipline
 
@@ -47,8 +56,13 @@ Knowledge lives in these notes; executable runbooks live under `.agents/skills/`
 
 ### Skills (runbooks)
 
+QA runbooks live at the repository root under `.agents/skills/` (not `.claude/skills/`, which
+holds the wiki-authoring skills). Each reads the notes above.
+
+- `.agents/skills/exploratory-session` — drive a newly shipped feature through the Playwright MCP and produce a session report; the first step of the new-feature flow.
 - `.agents/skills/test-case-design` — equivalence-partition a feature into a covering test set.
 - `.agents/skills/regression-sweep` — broad health check across a surface (SEO, perf, page-type matrix).
+- `.agents/skills/bug-retest-triage` — retest a reported defect on the live board and reach an evidence-backed verdict.
 
 ### Durable verification records
 
@@ -69,6 +83,7 @@ link the supporting evidence.
 
 ## Related Notes
 
+[Exploratory Session Inputs](Exploratory%20Session%20Inputs.md)
 [Environments & Access Matrix](Environments%20%26%20Access%20Matrix.md)
 [Bug Retest & Triage Process](Bug%20Retest%20%26%20Triage%20Process.md)
 [QA Engineer (Test Agent)](../market/personas/QA%20Engineer%20%28Test%20Agent%29.md)


### PR DESCRIPTION
## Why

Fills the gaps flagged on the QA process board (`mirumee/nimara` → `llm-wiki/quality`): the team has an AI-driven bug/new-feature testing flow, but no defined TestCase/TestPlan format, no skill describing how the AI tests via the Playwright MCP / exploratory session, and an incomplete skills list in the Quality MOC.

## What

- **`_templates/TestCase.md`** and **`_templates/TestPlan.md`** — generic templates (no record contract) formalising the QA work-products already written under `qa/`. Deliberately *not* new wiki record types: instances are runtime artifacts, not durable records.
- **`.agents/skills/exploratory-session/`** — new QA runbook: drive a newly shipped feature through the Playwright MCP and produce an evidence-backed session report. This is the first step of the new-feature flow, ahead of `test-case-design`.
- **`quality/Exploratory Session Inputs.md`** — documents what an exploratory session needs and reviews the PRD template against it. **Verdict: the current PRD format is sufficient to trigger a session; no PRD-template change is required** (env/channel and test data are correctly owned by QA notes, not the PRD).
- **`quality/Quality & Testing (MOC).md`** — completed and corrected the Skills list so it names every real QA runbook under `.agents/skills/` (was missing `bug-retest-triage`, now adds `exploratory-session`); linked the new formats and inputs note.
- Registered the new templates and note in `index.md`; appended a `log.md` entry.

## Verification

- `pnpm wiki:lint` → **0 violations across 96 files**.
- Docs/knowledge-base only; no application code changed.

## Notes for reviewers

- `.agents/skills/*` files are **not** covered by `wiki:lint` — a human read of the new `SKILL.md` is worth it.
- Open question for maintainers: should test cases/plans stay QA work-products (this PR), or become durable, linted, registered wiki record types? The latter is a larger schema change and can be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)