### PR TITLE
feat: add new test scenario - Happy path checkout

### DIFF
--- a/apps/automated-tests/codecept.conf.ts
+++ b/apps/automated-tests/codecept.conf.ts
@@ -29,5 +29,9 @@ export const config = {
   },
   include: {
     homepage: "./codecept/pages/homepage.ts",
+    homepagePage: "./codecept/pages/homepagePage.ts",
+    productPage: "./codecept/pages/productPage.ts",
+    checkoutPage: "./codecept/pages/checkoutPage.ts",
+    cartPage: "./codecept/pages/cartPage.ts",
   },
 };

--- a/apps/automated-tests/codecept/data/constants.ts
+++ b/apps/automated-tests/codecept/data/constants.ts
@@ -1,0 +1,82 @@
+import { locate } from "codeceptjs";
+
+import { LOCALE_PREFIX } from "../data/locales";
+
+export const timeout_seconds = 8; // timeout for wait funtions used in tests
+
+export const URLS = {
+  CART_PAGE: `${LOCALE_PREFIX}/cart`,
+  CHECKOUT_PAGE_USER_DETAILS: `${LOCALE_PREFIX}/checkout?step=user-details`,
+  CHECKOUT_PAGE_SHIPPING_ADDRESS: `${LOCALE_PREFIX}/checkout?step=shipping-address`,
+  CHECKOUT_PAGE_DELIVERY_METHOD: `${LOCALE_PREFIX}/checkout?step=delivery-method`,
+  CHECKOUT_PAGE_PAYMENT: `${LOCALE_PREFIX}/checkout?step=payment`,
+  ORDER_CONFIRMATION_PAGE: `${LOCALE_PREFIX}/order/confirmation/*`,
+  CHECKOUT_PAGE_SIGN_IN: `${LOCALE_PREFIX}/checkout/sign-in`,
+  HOME_PAGE: `${LOCALE_PREFIX}`,
+  SIGN_IN_PAGE: `${LOCALE_PREFIX}/sign-in`,
+  SIGN_IN_PAGE_RESULT: `${LOCALE_PREFIX}?loggedIn=`,
+  RESET_PASSWORD: `${LOCALE_PREFIX}/reset-password`,
+  CREATE_ACCOUNT: `${LOCALE_PREFIX}/create-account`,
+  PRODUCTS_PAGE: `${LOCALE_PREFIX}/search`,
+  PRODUCT_PAGE: `${LOCALE_PREFIX}/products`,
+  CATEGORY_PAGE: `${LOCALE_PREFIX}/categories`,
+  TSHIRT_PRODUCT_PAGE: `${LOCALE_PREFIX}/products/abstract-tshirt-black`,
+} as const;
+
+export const tshirtImagelocator = locate("img").withAttr({
+  "aria-label": "Abstract Tshirt Ultra Black",
+});
+
+export const storeHeaders = {
+  heroBanner: "Power your store with Nimara",
+  productsCarousel: "Nimara's products",
+  productsCarouselDescription:
+    "See what Nimara Store has to offer in the storefront demo version.",
+  newsletter: "Subscribe to Newsletter",
+  productListingPage: "All Nimara’s best products",
+  cookiePopup: "We use cookies",
+  cookieAccept: "Accept all",
+  orderSuccess: "Your order has been successfully placed",
+};
+
+export const userGB = {
+  email: "test@mirumee.com",
+  name: "John",
+  lastName: "Doe",
+  companyName: "Mirumee",
+  phone: "20 8759 9036",
+  streetAddress: "17 Wern Ddu Lane",
+  postCode: "PE8 6FZ",
+  city: "Lutton",
+};
+
+export const userUS = {
+  email: "test@example.com",
+  name: "John",
+  lastName: "Doe",
+  companyName: "Mirumee",
+  phone: "(212)555-0000",
+  streetAddress: "123 Main St",
+  postCode: "93721",
+  city: "Fresno",
+  state: "California",
+};
+
+export type User = typeof userGB | typeof userUS;
+
+export const userEmail = process.env.USER_EMAIL ?? "";
+export const userPassword = process.env.USER_PASSWORD ?? "";
+
+// Card variants and test payment data used by automated tests
+export const card = {
+  number: {
+    valid: "4242 4242 4242 4242",
+    invalid: "1234 5678 9012 3456",
+    stolen: "4000 0000 0000 0002",
+    declined: "4000 0000 0000 9995",
+    expired: "4000 0000 0000 0069",
+  },
+  expiration: `12/${(new Date().getFullYear() + 1).toString().substring(2)}`,
+  CVC: "500",
+  postalCode: "12345",
+};

--- a/apps/automated-tests/codecept/data/locales.ts
+++ b/apps/automated-tests/codecept/data/locales.ts
@@ -1,0 +1,11 @@
+const LOCALE_DICTIONARY: Record<string, string> = {
+  us: "",
+  gb: "/gb",
+};
+
+// LOCALE - default to "us" if not provided
+export const REQUESTED_LOCALE = process.env.LOCALE?.toLowerCase() || "us";
+
+// Sets prefix for URLs used in tests
+export const LOCALE_PREFIX =
+  LOCALE_DICTIONARY[REQUESTED_LOCALE] || LOCALE_DICTIONARY["us"];

--- a/apps/automated-tests/codecept/guest_checkout_test.ts
+++ b/apps/automated-tests/codecept/guest_checkout_test.ts
@@ -1,0 +1,26 @@
+import { storeHeaders, timeout_seconds } from "./data/constants";
+
+export {};
+
+Feature("Guest Checkout");
+
+Scenario(
+  "Full process from entry to checkout and payment - positive",
+  async ({ I, homepagePage, productPage, cartPage, checkoutPage }) => {
+    homepagePage.enter_page();
+    homepagePage.accept_cookies();
+    homepagePage.click_on_product(timeout_seconds);
+    productPage.add_example_tshirt_to_cart(timeout_seconds);
+    productPage.click_go_to_bag_popup(timeout_seconds);
+    //productPage.go_to_bag(timeout_seconds);
+    cartPage.go_to_checkout_from_bag(timeout_seconds);
+    checkoutPage.continue_as_guest(timeout_seconds);
+    checkoutPage.guest_step1_email(timeout_seconds);
+    await checkoutPage.guest_step2_continue_as_guest();
+    checkoutPage.guest_step3_shipping_address(timeout_seconds);
+    checkoutPage.guest_step4_shipping_method_dhl_normal(timeout_seconds);
+    checkoutPage.guest_step5_payment_details("valid", timeout_seconds);
+    checkoutPage.click_place_order(timeout_seconds);
+    I.waitForText(storeHeaders.orderSuccess, timeout_seconds);
+  },
+);

--- a/apps/automated-tests/codecept/pages/cartPage.ts
+++ b/apps/automated-tests/codecept/pages/cartPage.ts
@@ -1,0 +1,13 @@
+import { URLS } from "codecept/data/constants";
+import { locate } from "codeceptjs";
+
+const { I } = inject();
+
+export default {
+  go_to_checkout_from_bag(timeout: number) {
+    I.waitInUrl(URLS.CART_PAGE, timeout);
+    I.waitForElement(locate("a").withText("Go to checkout"), timeout);
+    I.click({ role: "link", name: "Go to checkout" });
+    I.waitInUrl(URLS.CHECKOUT_PAGE_SIGN_IN, timeout);
+  },
+};

--- a/apps/automated-tests/codecept/pages/checkoutPage.ts
+++ b/apps/automated-tests/codecept/pages/checkoutPage.ts
@@ -1,0 +1,143 @@
+import { locate } from "codeceptjs";
+
+import {
+  card as cardConstants,
+  timeout_seconds,
+  URLS,
+  userGB,
+  userUS,
+} from "../data/constants";
+import { REQUESTED_LOCALE } from "../data/locales";
+
+const { I } = inject();
+// select locale-specific user data from constants
+const selectedUser = REQUESTED_LOCALE === "us" ? userUS : userGB;
+const customer = {
+  firstName: selectedUser.name,
+  lastName: selectedUser.lastName,
+  companyName: selectedUser.companyName,
+  email: selectedUser.email,
+  city: selectedUser.city,
+  zip: selectedUser.postCode,
+  phone: selectedUser.phone,
+  streetAddress: selectedUser.streetAddress,
+  state: selectedUser.state || "",
+};
+
+// payment card data sourced from constants
+const card = cardConstants;
+
+export default {
+  continue_as_guest(timeout: number = timeout_seconds) {
+    I.waitForElement(locate("a").withText("Continue as a guest"), timeout);
+    I.click({ role: "link", name: "Continue as a guest" });
+    I.waitInUrl(URLS.CHECKOUT_PAGE_USER_DETAILS, timeout);
+  },
+
+  guest_step1_email(timeout: number = timeout_seconds) {
+    I.waitForElement('input[aria-label="Email"]', timeout);
+    I.fillField({ role: "textbox", name: "Email" }, customer.email);
+    I.click({ role: "button", name: "Continue" });
+    I.waitToHide('input[aria-label="Email"]', timeout);
+  },
+  async guest_step2_continue_as_guest() {
+    const count = await I.grabNumberOfVisibleElements({
+      role: "button",
+      name: "Continue as a guest",
+    });
+
+    if (count > 0) {
+      console.log(
+        "Guest checkout step 2: Continue as guest button is visible, clicking it.",
+      );
+      I.click({ role: "button", name: "Continue as a guest" });
+    }
+  },
+  guest_step3_shipping_address(timeout: number = timeout_seconds) {
+    I.waitInUrl(URLS.CHECKOUT_PAGE_SHIPPING_ADDRESS, timeout);
+    I.waitForElement('input[aria-label="First Name"]', timeout);
+    I.fillField({ role: "textbox", name: "First Name" }, customer.firstName);
+    I.fillField({ role: "textbox", name: "Last Name" }, customer.lastName);
+    I.fillField(
+      { role: "textbox", name: "Company name" },
+      customer.companyName,
+    );
+    I.fillField(
+      { role: "textbox", name: "Street address" },
+      customer.streetAddress,
+    );
+    I.fillField({ role: "textbox", name: "Phone" }, customer.phone);
+    I.scrollPageToBottom();
+
+    // Locale specific form filling
+    switch (REQUESTED_LOCALE?.toLowerCase()) {
+      case "gb":
+        I.fillField({ role: "textbox", name: "Post town" }, customer.city);
+        I.fillField({ role: "textbox", name: "Postal" }, customer.zip);
+        break;
+
+      case "us":
+        // 'State' combobox exists only for some locales (e.g., US). Fill it conditionally.
+        I.fillField({ role: "textbox", name: "City" }, customer.city);
+        I.fillField({ role: "textbox", name: "Zip" }, customer.zip);
+        I.click({ role: "combobox", name: "State" });
+        I.click(customer.state as string);
+        break;
+
+      default:
+        console.warn(
+          `No specific form filling logic for locale: ${REQUESTED_LOCALE}`,
+        );
+        break;
+    }
+    I.click("Continue");
+  },
+
+  guest_step4_shipping_method_dhl_normal(timeout: number = timeout_seconds) {
+    I.waitInUrl(URLS.CHECKOUT_PAGE_DELIVERY_METHOD, timeout);
+    const dhlNormalOption = locate("label").withText("DHL Normal");
+
+    I.waitForVisible(dhlNormalOption, timeout);
+    I.click(dhlNormalOption);
+    I.click("Continue");
+  },
+
+  guest_step5_payment_details(
+    card_characteristics:
+      | "valid"
+      | "invalid"
+      | "stolen"
+      | "declined"
+      | "expired",
+    timeout: number = timeout_seconds,
+  ) {
+    I.waitInUrl(URLS.CHECKOUT_PAGE_PAYMENT, timeout);
+    I.scrollPageToBottom();
+    I.waitForElement(
+      locate('iframe[title*="Secure payment input frame"]').first(),
+      timeout,
+    );
+    I.switchTo(locate('iframe[title*="Secure payment input frame"]').first());
+    I.waitForVisible('div[class="p-PaymentAccordionButtonView"]', timeout);
+    const cardNumber = card.number[card_characteristics] || card.number.valid;
+
+    I.fillField("Card number", cardNumber);
+    I.fillField("MM / YY", card.expiration);
+    I.fillField("Security code", card.CVC);
+    I.switchTo();
+  },
+
+  click_place_order(timeout: number = timeout_seconds) {
+    //I.waitForClickable({ role: "button", name: "Place order" }, timeout);
+    I.click({ role: "button", name: "Place order" });
+  },
+  click_billing_address_same_as_shipping_checkbox(
+    timeout: number = timeout_seconds,
+  ) {
+    I.waitForClickable(
+      { role: "checkbox", name: "Same as shipping address" },
+      timeout,
+    );
+    I.click({ role: "checkbox", name: "Same as shipping address" });
+  },
+};

--- a/apps/automated-tests/codecept/pages/homepagePage.ts
+++ b/apps/automated-tests/codecept/pages/homepagePage.ts
@@ -1,0 +1,18 @@
+import { storeHeaders, tshirtImagelocator, URLS } from "../data/constants";
+
+const { I } = inject();
+
+export default {
+  enter_page() {
+    I.amOnPage(URLS.HOME_PAGE);
+  },
+  accept_cookies() {
+    I.click(storeHeaders.cookieAccept);
+    I.dontSee(storeHeaders.cookiePopup);
+  },
+  click_on_product(timeout: number) {
+    I.scrollTo(tshirtImagelocator);
+    I.click(tshirtImagelocator);
+    I.waitUrlEquals(URLS.TSHIRT_PRODUCT_PAGE, timeout);
+  },
+};

--- a/apps/automated-tests/codecept/pages/productPage.ts
+++ b/apps/automated-tests/codecept/pages/productPage.ts
@@ -1,0 +1,43 @@
+import { locate } from "codeceptjs";
+
+import { URLS } from "../data/constants";
+
+const { I } = inject();
+
+export default {
+  add_example_tshirt_to_cart(timeout: number) {
+    I.waitForVisible({ role: "radio", name: "L" }, timeout);
+    I.click({ role: "radio", name: "L" });
+    I.waitForVisible({ role: "combobox", name: "Variant select" }, timeout);
+    I.click({ role: "combobox", name: "Variant select" });
+    I.click("L regular");
+    I.click(locate("button").withText("Add to bag"));
+  },
+  click_go_to_bag_popup(timeout: number) {
+    I.waitForVisible({ role: "link", name: "Go to bag" }, timeout);
+    I.waitForFunction(
+      // waiting for the animation to finish before clicking
+      (selector: string) => {
+        const el = document.querySelector(selector);
+
+        if (!el) {
+          return false;
+        }
+        const animations = el.getAnimations();
+
+        return (
+          animations.length === 0 ||
+          animations.every((a: Animation) => a.playState === "finished")
+        );
+      },
+      ['li[data-state="open"]'],
+      timeout,
+    );
+    I.click({ role: "link", name: "Go to bag" });
+  },
+
+  go_to_bag(timeout: number) {
+    I.click({ role: "link", name: /Items in cart/ as unknown as string });
+    I.waitInUrl(URLS.CART_PAGE, timeout);
+  },
+};

--- a/apps/automated-tests/steps.d.ts
+++ b/apps/automated-tests/steps.d.ts
@@ -1,11 +1,19 @@
 /// <reference types='codeceptjs' />
 type homepage = typeof import("./codecept/pages/homepage").default;
+type homepagePage = typeof import("./codecept/pages/homepagePage").default;
+type productPage = typeof import("./codecept/pages/productPage").default;
+type checkoutPage = typeof import("./codecept/pages/checkoutPage").default;
+type cartPage = typeof import("./codecept/pages/cartPage").default;
 
 declare namespace CodeceptJS {
   interface SupportObject {
     I: I;
+    cartPage: cartPage;
+    checkoutPage: checkoutPage;
     current: any;
     homepage: homepage;
+    homepagePage: homepagePage;
+    productPage: productPage;
   }
   interface Methods extends Playwright {}
   interface I extends WithTranslation<Methods> {}

--- a/apps/automated-tests/tsconfig.json
+++ b/apps/automated-tests/tsconfig.json
@@ -6,6 +6,7 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "resolveJsonModule": true
   }
 }

--- a/apps/automated-tests/tsconfig.json
+++ b/apps/automated-tests/tsconfig.json
@@ -6,7 +6,6 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
-    },
-    "resolveJsonModule": true
+    }
   }
 }

--- a/apps/automated-tests/turbo.json
+++ b/apps/automated-tests/turbo.json
@@ -3,7 +3,7 @@
   "tasks": {
     "test:e2e": {
       "dependsOn": ["test"],
-      "env": ["TEST_ENV_URL"],
+      "env": ["TEST_ENV_URL", "LOCALE"],
       "passThroughEnv": ["USER_EMAIL", "USER_PASSWORD"],
       "inputs": [
         "./tests/e2e/**/*.test.ts",


### PR DESCRIPTION
Why?

Adding a happy path checkout test in codecept

What changed
Changed ts config in automated tests to include JSON parsing

apps/automated-tests/codecept/guest_checkout_test.ts - test scenario itself
apps/automated-tests/codecept/pages/homepagePage.ts - functions used by the scenario
apps/automated-tests/codecept/pages/productPage.ts - functions used by the scenario
apps/automated-tests/codecept/pages/cartPage.ts - functions used by the scenario
apps/automated-tests/codecept/pages/checkoutPage.ts - functions used by the scenario
apps/automated-tests/codecept/data/constants.ts - data used by the happy path test
apps/automated-tests/codecept/data/locales.js - handling locale choice

apps/automated-tests/turbo.json - handling new locale
apps/automated-tests/codecept.conf.ts - codecept config
apps/automated-tests/steps.d.ts - auto generated