### PR TITLE
fix: bound form field lengths and surface server-side form errors

### DIFF
--- a/apps/storefront/src/app/[locale]/(auth)/create-account/schema.ts
+++ b/apps/storefront/src/app/[locale]/(auth)/create-account/schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { FIELD_MAX_LENGTH } from "@nimara/domain/consts";
 import { type GetTranslations } from "@nimara/i18n/types";
 
 import { MIN_PASSWORD_LENGTH } from "@/config";
@@ -10,16 +11,31 @@ export const formSchema = ({ t }: { t: GetTranslations }) =>
       firstName: z
         .string()
         .min(1, { message: t("form-validation.required") })
-        .trim(),
+        .trim()
+        .max(FIELD_MAX_LENGTH.firstName, {
+          message: t("form-validation.max-length", {
+            maximum: FIELD_MAX_LENGTH.firstName,
+          }),
+        }),
       lastName: z
         .string()
         .min(1, { message: t("form-validation.required") })
-        .trim(),
+        .trim()
+        .max(FIELD_MAX_LENGTH.lastName, {
+          message: t("form-validation.max-length", {
+            maximum: FIELD_MAX_LENGTH.lastName,
+          }),
+        }),
       email: z
         .string()
         .min(1, { message: t("form-validation.required") })
         .email({ message: t("form-validation.invalid-email") })
-        .trim(),
+        .trim()
+        .max(FIELD_MAX_LENGTH.email, {
+          message: t("form-validation.max-length", {
+            maximum: FIELD_MAX_LENGTH.email,
+          }),
+        }),
       password: z
         .string()
         .min(MIN_PASSWORD_LENGTH, {

--- a/apps/storefront/src/app/[locale]/(main)/account/addresses/_forms/create-address-form.tsx
+++ b/apps/storefront/src/app/[locale]/(main)/account/addresses/_forms/create-address-form.tsx
@@ -18,6 +18,7 @@ import { Button } from "@nimara/ui/components/button";
 import { DialogClose } from "@nimara/ui/components/dialog";
 import { useToast } from "@nimara/ui/hooks";
 
+import { isGlobalError } from "@/foundation/errors/errors";
 import { storefrontLogger } from "@/services/logging";
 
 import { createNewAddress } from "./actions";
@@ -71,6 +72,20 @@ export const AddNewAddressForm = ({
 
     if (!result.ok) {
       storefrontLogger.error("Address create failed", { result });
+
+      result.errors.forEach(({ field, code }) => {
+        if (isGlobalError(field)) {
+          toast({
+            variant: "destructive",
+            description: t(`errors.${code}`),
+            position: "center",
+          });
+        } else {
+          form.setError(field as keyof FormSchema, {
+            message: t(`errors.${code}`),
+          });
+        }
+      });
 
       return;
     }

--- a/apps/storefront/src/app/[locale]/(main)/account/addresses/_forms/update-address-form.tsx
+++ b/apps/storefront/src/app/[locale]/(main)/account/addresses/_forms/update-address-form.tsx
@@ -14,7 +14,9 @@ import { AddressForm } from "@nimara/foundation/address/address-form/address-for
 import { CheckboxField } from "@nimara/foundation/form-components/checkbox-field";
 import { ADDRESS_CORE_FIELDS } from "@nimara/infrastructure/consts";
 import { Button } from "@nimara/ui/components/button";
+import { useToast } from "@nimara/ui/hooks";
 
+import { isGlobalError } from "@/foundation/errors/errors";
 import { storefrontLogger } from "@/services/logging";
 
 import { updateAddress } from "./actions";
@@ -44,6 +46,7 @@ export const EditAddressForm = ({
   onModeChange: () => void;
 }) => {
   const t = useTranslations();
+  const { toast } = useToast();
 
   const [isCountryChanging, setIsCountryChanging] = useState(false);
 
@@ -67,8 +70,21 @@ export const EditAddressForm = ({
     const result = await updateAddress({ id: address.id, input: values });
 
     if (!result.ok) {
-      // TODO: Handle in UI
       storefrontLogger.error("Address update failed", { result });
+
+      result.errors.forEach(({ field, code }) => {
+        if (isGlobalError(field)) {
+          toast({
+            variant: "destructive",
+            description: t(`errors.${code}`),
+            position: "center",
+          });
+        } else {
+          form.setError(field as keyof FormSchema, {
+            message: t(`errors.${code}`),
+          });
+        }
+      });
 
       return;
     }

--- a/apps/storefront/src/app/[locale]/(main)/account/profile/_forms/schema.ts
+++ b/apps/storefront/src/app/[locale]/(main)/account/profile/_forms/schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { FIELD_MAX_LENGTH } from "@nimara/domain/consts";
 import { type GetTranslations } from "@nimara/i18n/types";
 
 import { MIN_PASSWORD_LENGTH } from "@/config";
@@ -9,11 +10,21 @@ export const updateNameFormSchema = ({ t }: { t: GetTranslations }) =>
     firstName: z
       .string()
       .min(1, { message: t("form-validation.required") })
-      .trim(),
+      .trim()
+      .max(FIELD_MAX_LENGTH.firstName, {
+        message: t("form-validation.max-length", {
+          maximum: FIELD_MAX_LENGTH.firstName,
+        }),
+      }),
     lastName: z
       .string()
       .min(1, { message: t("form-validation.required") })
-      .trim(),
+      .trim()
+      .max(FIELD_MAX_LENGTH.lastName, {
+        message: t("form-validation.max-length", {
+          maximum: FIELD_MAX_LENGTH.lastName,
+        }),
+      }),
   });
 
 export const updateEmailFormSchema = ({ t }: { t: GetTranslations }) =>
@@ -22,7 +33,12 @@ export const updateEmailFormSchema = ({ t }: { t: GetTranslations }) =>
       .string()
       .min(1, { message: t("form-validation.required") })
       .email({ message: t("form-validation.invalid-email") })
-      .trim(),
+      .trim()
+      .max(FIELD_MAX_LENGTH.email, {
+        message: t("form-validation.max-length", {
+          maximum: FIELD_MAX_LENGTH.email,
+        }),
+      }),
     password: z
       .string()
       .min(MIN_PASSWORD_LENGTH, {

--- a/apps/storefront/src/app/[locale]/(main)/account/profile/_forms/update-name-form.tsx
+++ b/apps/storefront/src/app/[locale]/(main)/account/profile/_forms/update-name-form.tsx
@@ -10,6 +10,8 @@ import { Button } from "@nimara/ui/components/button";
 import { DialogFooter } from "@nimara/ui/components/dialog";
 import { useToast } from "@nimara/ui/hooks";
 
+import { isGlobalError } from "@/foundation/errors/errors";
+
 import { updateUserName } from "./actions";
 import { type UpdateNameFormSchema, updateNameFormSchema } from "./schema";
 
@@ -34,9 +36,22 @@ export function UpdateNameForm({
   async function handleSubmit(values: UpdateNameFormSchema) {
     const result = await updateUserName(values);
 
-    if (result && !result.ok) {
-      form.setError("firstName", { message: "" });
-      form.setError("lastName", { message: "" });
+    if (!result.ok) {
+      result.errors.forEach(({ field, code }) => {
+        if (isGlobalError(field)) {
+          toast({
+            variant: "destructive",
+            description: t(`errors.${code}`),
+            position: "center",
+          });
+        } else {
+          form.setError(field as keyof UpdateNameFormSchema, {
+            message: t(`errors.${code}`),
+          });
+        }
+      });
+
+      return;
     }
 
     toast({

--- a/apps/storefront/src/foundation/checkout/sections/user-details/schema.ts
+++ b/apps/storefront/src/foundation/checkout/sections/user-details/schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { FIELD_MAX_LENGTH } from "@nimara/domain/consts";
 import { type GetTranslations } from "@nimara/i18n/types";
 
 export const userDetailsEmailFormSchema = ({ t }: { t: GetTranslations }) =>
@@ -8,7 +9,12 @@ export const userDetailsEmailFormSchema = ({ t }: { t: GetTranslations }) =>
       .string()
       .min(1, { message: t("form-validation.required") })
       .email({ message: t("form-validation.invalid-email") })
-      .trim(),
+      .trim()
+      .max(FIELD_MAX_LENGTH.email, {
+        message: t("form-validation.max-length", {
+          maximum: FIELD_MAX_LENGTH.email,
+        }),
+      }),
   });
 
 export const userDetailsPasswordFormSchema = ({ t }: { t: GetTranslations }) =>

--- a/packages/domain/src/consts.ts
+++ b/packages/domain/src/consts.ts
@@ -283,3 +283,16 @@ export const ALLOWED_CURRENCY_CODES = [
  * @see https://en.wikipedia.org/wiki/ISO_4217
  */
 export type AllCurrency = (typeof ALLOWED_CURRENCY_CODES)[number];
+
+export const FIELD_MAX_LENGTH = {
+  email: 254,
+  firstName: 256,
+  lastName: 256,
+  companyName: 256,
+  streetAddress1: 256,
+  streetAddress2: 256,
+  city: 256,
+  cityArea: 128,
+  countryArea: 128,
+  postalCode: 20,
+} as const;

--- a/packages/features/src/home-page/shared/schema/newsletter.ts
+++ b/packages/features/src/home-page/shared/schema/newsletter.ts
@@ -1,17 +1,34 @@
 import { z } from "zod";
 
+import { FIELD_MAX_LENGTH } from "@nimara/domain/consts";
 import { type GetTranslations } from "@nimara/i18n/types";
+
+/**
+ * No subscription provider is wired up yet, so nothing downstream dictates this
+ * bound. It matches the account name limit to keep the storefront consistent.
+ */
+const MAX_NAME_LENGTH = 256;
 
 export const formSchema = ({ t }: { t: GetTranslations }) =>
   z.object({
     name: z
       .string()
       .trim()
-      .min(1, { message: t("form-validation.required") }),
+      .min(1, { message: t("form-validation.required") })
+      .max(MAX_NAME_LENGTH, {
+        message: t("form-validation.max-length", {
+          maximum: MAX_NAME_LENGTH,
+        }),
+      }),
     email: z
       .string()
       .email({ message: t("form-validation.invalid-email") })
-      .trim(),
+      .trim()
+      .max(FIELD_MAX_LENGTH.email, {
+        message: t("form-validation.max-length", {
+          maximum: FIELD_MAX_LENGTH.email,
+        }),
+      }),
   });
 
 export type FormSchema = z.infer<ReturnType<typeof formSchema>>;

--- a/packages/foundation/src/address/address-form/schema.ts
+++ b/packages/foundation/src/address/address-form/schema.ts
@@ -1,8 +1,30 @@
 import { z } from "zod";
 
-import { ALLOWED_COUNTRY_CODES } from "@nimara/domain/consts";
+import { ALLOWED_COUNTRY_CODES, FIELD_MAX_LENGTH } from "@nimara/domain/consts";
 import { type AddressFormRow } from "@nimara/domain/objects/AddressForm";
 import { type GetTranslations } from "@nimara/i18n/types";
+
+type BoundedFieldName = keyof typeof FIELD_MAX_LENGTH;
+
+const boundedField = ({
+  addressFormRows,
+  fieldName,
+  t,
+}: {
+  addressFormRows: readonly AddressFormRow[];
+  fieldName: BoundedFieldName;
+  t: GetTranslations;
+}) =>
+  z
+    .string()
+    .trim()
+    .max(FIELD_MAX_LENGTH[fieldName], {
+      message: t("form-validation.max-length", {
+        maximum: FIELD_MAX_LENGTH[fieldName],
+      }),
+    })
+    .optional()
+    .superRefine(checkIfRequired({ addressFormRows, fieldName, t }));
 
 export const addressSchema = ({
   addressFormRows,
@@ -13,72 +35,29 @@ export const addressSchema = ({
 }) =>
   z.object({
     country: z.enum(ALLOWED_COUNTRY_CODES),
-    firstName: z
-      .string()
-      .trim()
-      .optional()
-      .superRefine(
-        checkIfRequired({ addressFormRows, fieldName: "firstName", t }),
-      ),
-    lastName: z
-      .string()
-      .trim()
-      .optional()
-      .superRefine(
-        checkIfRequired({ addressFormRows, fieldName: "lastName", t }),
-      ),
-    city: z
-      .string()
-      .trim()
-      .optional()
-      .superRefine(checkIfRequired({ addressFormRows, fieldName: "city", t })),
+    firstName: boundedField({ addressFormRows, fieldName: "firstName", t }),
+    lastName: boundedField({ addressFormRows, fieldName: "lastName", t }),
+    city: boundedField({ addressFormRows, fieldName: "city", t }),
+    // Saleor validates the phone against the country's numbering plan, not a character count.
     phone: z
       .string()
       .trim()
       .optional()
       .superRefine(checkIfRequired({ addressFormRows, fieldName: "phone", t })),
-    postalCode: z
-      .string()
-      .trim()
-      .optional()
-      .superRefine(
-        checkIfRequired({ addressFormRows, fieldName: "postalCode", t }),
-      ),
-    companyName: z
-      .string()
-      .trim()
-      .optional()
-      .superRefine(
-        checkIfRequired({ addressFormRows, fieldName: "companyName", t }),
-      ),
-    cityArea: z
-      .string()
-      .trim()
-      .optional()
-      .superRefine(
-        checkIfRequired({ addressFormRows, fieldName: "cityArea", t }),
-      ),
-    streetAddress1: z
-      .string()
-      .trim()
-      .optional()
-      .superRefine(
-        checkIfRequired({ addressFormRows, fieldName: "streetAddress1", t }),
-      ),
-    streetAddress2: z
-      .string()
-      .trim()
-      .optional()
-      .superRefine(
-        checkIfRequired({ addressFormRows, fieldName: "streetAddress2", t }),
-      ),
-    countryArea: z
-      .string()
-      .trim()
-      .optional()
-      .superRefine(
-        checkIfRequired({ addressFormRows, fieldName: "countryArea", t }),
-      ),
+    postalCode: boundedField({ addressFormRows, fieldName: "postalCode", t }),
+    companyName: boundedField({ addressFormRows, fieldName: "companyName", t }),
+    cityArea: boundedField({ addressFormRows, fieldName: "cityArea", t }),
+    streetAddress1: boundedField({
+      addressFormRows,
+      fieldName: "streetAddress1",
+      t,
+    }),
+    streetAddress2: boundedField({
+      addressFormRows,
+      fieldName: "streetAddress2",
+      t,
+    }),
+    countryArea: boundedField({ addressFormRows, fieldName: "countryArea", t }),
   });
 
 export const checkIfRequired =

--- a/packages/i18n/src/messages/en/common.json
+++ b/packages/i18n/src/messages/en/common.json
@@ -253,6 +253,7 @@
     "Invalid value": "Invalid value",
     "enter-discount-code": "Type the discount code first",
     "invalid-email": "Oops, wrong email address.",
+    "max-length": "Use at most {maximum} characters.",
     "min-length-password": "Password should contain at least {minimum} characters.",
     "oldPassword": "Wrong password",
     "passwords-dont-match": "The entered passwords don't match.",


### PR DESCRIPTION
I want to merge this change because long input silently failed: schemas had no upper bound, so oversized values reached Saleor and the resulting errors were either logged only or shown as empty field messages.

Add FIELD_MAX_LENGTH in @nimara/domain, apply it across the account, checkout, newsletter and address schemas, and map action errors onto the matching field or a toast.

<!-- Please mention all relevant issue numbers. -->

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Target `main` from a short-lived change branch and use a Conventional Commit PR title.
- [ ] Test the changes locally to ensure they work as expected.
- [ ] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Verify all four Vercel project statuses: `nimara-docs`, `nimara-ecommerce`,
      `nimara-ecommerce-stripe`, and `nimara-marketplace`.
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [ ] Keep incomplete behavior disabled with a short-lived feature flag or branch-by-abstraction seam.
- [ ] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [ ] Update documentation to reflect any changes in functionality.
