### PR TITLE
chore(ucp): migrate the UCP adapter to @ucp-js/sdk 0.4.5

### DIFF
--- a/apps/storefront/package.json
+++ b/apps/storefront/package.json
@@ -26,7 +26,7 @@
     "@opentelemetry/api": "1.9.1",
     "@sentry/nextjs": "^10.70.0",
     "@sentry/types": "^10.70.0",
-    "@ucp-js/sdk": "0.1.0",
+    "@ucp-js/sdk": "0.4.5",
     "@uidotdev/usehooks": "2.4.1",
     "@vercel/otel": "^2.1.3",
     "@vercel/speed-insights": "1.3.1",

--- a/packages/infrastructure/package.json
+++ b/packages/infrastructure/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@saleor/auth-sdk": "1.0.3",
     "@stripe/stripe-js": "8.11.0",
-    "@ucp-js/sdk": "0.1.0",
+    "@ucp-js/sdk": "0.4.5",
     "editorjs-html": "3.4.3",
     "jose": "^6.2.9",
     "libphonenumber-js": "1.13.11",

--- a/packages/infrastructure/src/ucp/saleor/helpers.ts
+++ b/packages/infrastructure/src/ucp/saleor/helpers.ts
@@ -1,8 +1,10 @@
 import {
   type CheckoutResponse,
   type CheckoutUpdateRequest,
-  type LinkElement,
+  type Link,
   type PostalAddress,
+  type UcpDiscoveryProfile,
+  type UcpResponse,
 } from "@ucp-js/sdk";
 
 import { type AddressInput } from "@nimara/codegen/schema";
@@ -306,9 +308,9 @@ export const calculateCheckoutExpiration = (
  * Links are required by spec for legal compliance (privacy policy, TOS, etc).
  *
  * @param storefrontURL - Base URL for link construction (e.g., "https://example.com")
- * @returns Array of LinkElement with well-known types
+ * @returns Array of Link with well-known types
  */
-export const generateCheckoutLinks = (storefrontURL: string): LinkElement[] => {
+export const generateCheckoutLinks = (storefrontURL: string): Link[] => {
   return [
     {
       type: "privacy_policy",
@@ -381,3 +383,19 @@ export const generateContinueUrl = ({
 
   return checkoutURL.toString();
 };
+
+/**
+ * A discovery profile lists capabilities as an array carrying a name. A
+ * response envelope keys them by that name, so the name moves into the key.
+ */
+export const toResponseCapabilities = (
+  capabilities: UcpDiscoveryProfile["ucp"]["capabilities"],
+): NonNullable<UcpResponse["capabilities"]> =>
+  capabilities.reduce<NonNullable<UcpResponse["capabilities"]>>(
+    (registry, { name, ...entry }) => {
+      registry[name] = [...(registry[name] ?? []), entry];
+
+      return registry;
+    },
+    {},
+  );

--- a/packages/infrastructure/src/ucp/saleor/serializers.ts
+++ b/packages/infrastructure/src/ucp/saleor/serializers.ts
@@ -1,15 +1,15 @@
 import {
-  type BuyerClass,
+  type Buyer,
   type BuyerWithConsentResponse,
   type CheckoutResponse,
   type CheckoutResponseStatus,
   type CheckoutWithFulfillmentResponse,
+  type FulfillmentMethodResponse,
   type FulfillmentRequest,
   type LineItemResponse,
-  type LinkElement,
-  type MethodElement,
+  type Link,
   type Order as UcpOrder,
-  type OrderClass,
+  type OrderConfirmation,
   type PostalAddress,
   type TotalResponse,
   type UcpDiscoveryProfile,
@@ -22,6 +22,7 @@ import {
   formatDeliveryDays,
   generateCheckoutLinks,
   toMinorCurrency,
+  toResponseCapabilities,
 } from "#root/ucp/saleor/helpers";
 import type {
   UcpMedia,
@@ -52,7 +53,7 @@ export type UCPAppliedDiscount = {
 /**
  * Internal checkout session model bridging Saleor and UCP CheckoutResponse.
  * Uses SDK types where possible. Custom parts:
- * - order.permalinkUrl: camelCase internal; SDK OrderClass uses permalink_url (snake_case).
+ * - order.permalinkUrl: camelCase internal; SDK OrderConfirmation uses permalink_url (snake_case).
  * - continueUrl: For checkout handoff to business UI (will be converted to continue_url).
  * - expiresAtISO: ISO 8601 string for checkout expiration (will be converted to expires_at).
  * - messages: Error/warning messages array for error handling (Phase 2).
@@ -60,7 +61,7 @@ export type UCPAppliedDiscount = {
  */
 export type UCPCheckoutSessionModel = {
   billingAddress?: PostalAddress;
-  buyer?: BuyerClass;
+  buyer?: Buyer;
   continueUrl?: string;
   currency: string;
   discounts?: {
@@ -72,7 +73,7 @@ export type UCPCheckoutSessionModel = {
   fulfillmentAddress?: PostalAddress;
   id: string;
   lineItems: LineItemResponse[];
-  links: LinkElement[];
+  links: Link[];
   messages?: Array<{
     code: string;
     content: string;
@@ -85,8 +86,8 @@ export type UCPCheckoutSessionModel = {
       | "requires_buyer_review";
     type: "error" | "warning" | "info";
   }>;
-  order?: Pick<OrderClass, "id"> & {
-    permalinkUrl: OrderClass["permalink_url"];
+  order?: Pick<OrderConfirmation, "id"> & {
+    permalinkUrl: OrderConfirmation["permalink_url"];
   };
   status: CheckoutResponseStatus;
   totals: TotalResponse[];
@@ -305,7 +306,7 @@ const toFulfillmentMethod = (
     | "deliveryMethod"
     | "shippingPrice"
   >,
-): MethodElement | null => {
+): FulfillmentMethodResponse | null => {
   if (!checkout.shippingAddress || checkout.shippingMethods.length === 0) {
     return null;
   }
@@ -363,7 +364,7 @@ const toFulfillmentMethod = (
           (checkout.deliveryMethod as { id?: string } | null)?.id || null,
       },
     ],
-  } as unknown as MethodElement;
+  } as unknown as FulfillmentMethodResponse;
 };
 
 /**
@@ -507,7 +508,7 @@ export const sessionToCheckoutResponse = ({
     ucp: {
       version,
       status: "success",
-      capabilities,
+      capabilities: toResponseCapabilities(capabilities),
       payment_handlers: {},
     } as CheckoutWithFulfillmentResponse["ucp"],
     payment: {
@@ -528,9 +529,7 @@ export const sessionToCheckoutResponse = ({
           })) as NonNullable<CheckoutWithFulfillmentResponse["messages"]>,
         }
       : {}),
-    ...(session.expiresAtISO
-      ? { expires_at: new Date(session.expiresAtISO) }
-      : {}),
+    ...(session.expiresAtISO ? { expires_at: session.expiresAtISO } : {}),
     ...(session.continueUrl ? { continue_url: session.continueUrl } : {}),
     ...(session.order
       ? {
@@ -614,7 +613,7 @@ export const orderToUCPOrder = ({
           id: line.id,
           quantity: line.quantityFulfilled,
         })),
-        occurred_at: new Date(),
+        occurred_at: new Date().toISOString(),
       })),
     },
     totals: [
@@ -630,9 +629,9 @@ export const orderToUCPOrder = ({
     ucp: {
       version: UCP_VERSION,
       status: "success",
-      capabilities,
+      capabilities: toResponseCapabilities(capabilities),
     },
-  } as UcpOrder;
+  } satisfies UcpOrder;
 };
 
 // ── Catalog serializers ──────────────────────────────────────────

--- a/packages/infrastructure/src/ucp/saleor/service.ts
+++ b/packages/infrastructure/src/ucp/saleor/service.ts
@@ -494,7 +494,9 @@ export const saleorUCPService = ({
     }
   },
   updateCheckoutSession: async (
-    input: CheckoutUpdateRequest | CheckoutWithDiscountUpdateRequest,
+    input: (CheckoutUpdateRequest | CheckoutWithDiscountUpdateRequest) & {
+      id: string;
+    },
   ): UCPResponse<CheckoutResponse> => {
     const client = graphqlClient(apiUrl);
 

--- a/packages/infrastructure/src/ucp/saleor/types.ts
+++ b/packages/infrastructure/src/ucp/saleor/types.ts
@@ -1,7 +1,7 @@
 import {
-  type BuyerClass,
+  type Buyer,
   type CheckoutUpdateRequest,
-  type MethodElement,
+  type FulfillmentMethodResponse,
   type PostalAddress,
   type UcpDiscoveryProfile,
 } from "@ucp-js/sdk";
@@ -78,19 +78,19 @@ export type SaleorCheckoutLineInput = {
   variantId: string;
 };
 
-/** Fallback names when address omits them. Uses SDK BuyerClass fields. */
-export type NameFallback = Pick<BuyerClass, "first_name" | "last_name">;
+/** Fallback names when address omits them. Uses SDK Buyer fields. */
+export type NameFallback = Pick<Buyer, "first_name" | "last_name">;
 
-/** UCP fulfillment method shape for update. Uses SDK MethodElement. */
+/** UCP fulfillment method shape for update. Uses SDK FulfillmentMethodResponse. */
 export type UCPFulfillmentMethod = Pick<
-  MethodElement,
+  FulfillmentMethodResponse,
   "destinations" | "groups"
 >;
 
 /** Extended CheckoutUpdateRequest with Saleor-specific fulfillment and billing. */
 export type UCPUpdateRequestExtended = CheckoutUpdateRequest & {
   billing_address?: Partial<PostalAddress>;
-  buyer?: BuyerClass;
+  buyer?: Buyer;
   fulfillment?: {
     methods?: UCPFulfillmentMethod[];
   };

--- a/packages/infrastructure/src/ucp/types.ts
+++ b/packages/infrastructure/src/ucp/types.ts
@@ -16,6 +16,12 @@ export type UCPServiceError = BaseError & {
 
 export type UCPResponse<TRes> = AsyncResult<TRes, UCPServiceError>;
 
+/**
+ * The checkout id lives in the URL path, not in the request body. The service
+ * needs both, so callers pass the id next to the body fields.
+ */
+export type CheckoutUpdateInput = CheckoutUpdateRequest & { id: string };
+
 // ── Catalog types ──────────────────────────────────────────────
 
 export type CatalogSearchFilters = {
@@ -171,6 +177,6 @@ export type UCPService = {
    * @link https://ucp.dev/2026-04-08/specification/checkout/#update-checkout
    */
   updateCheckoutSession: (
-    input: CheckoutUpdateRequest,
+    input: CheckoutUpdateInput,
   ) => UCPResponse<CheckoutResponse>;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,8 +335,8 @@ importers:
         specifier: ^10.70.0
         version: 10.70.0
       '@ucp-js/sdk':
-        specifier: 0.1.0
-        version: 0.1.0
+        specifier: 0.4.5
+        version: 0.4.5
       '@uidotdev/usehooks':
         specifier: 2.4.1
         version: 2.4.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -978,8 +978,8 @@ importers:
         specifier: 8.11.0
         version: 8.11.0
       '@ucp-js/sdk':
-        specifier: 0.1.0
-        version: 0.1.0
+        specifier: 0.4.5
+        version: 0.4.5
       editorjs-html:
         specifier: 3.4.3
         version: 3.4.3
@@ -7224,8 +7224,8 @@ packages:
     resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
-  '@ucp-js/sdk@0.1.0':
-    resolution: {integrity: sha512-Elgaxj5mhHobebeUjwpg6dh+b5uE01/efJo6Xq2UDk7P/rvXgPwi74aTMYL3XgAqWIeijerI5Hid1c6I549yoQ==}
+  '@ucp-js/sdk@0.4.5':
+    resolution: {integrity: sha512-KS80aNxoOUpOrIqhvpT7tKXATch8yWJgGLAzLGACUFpQeAy3UljFi3TEgKEdJNJbEMQ+aF/a7F+J6c+VB2RRLw==}
 
   '@uidotdev/usehooks@2.4.1':
     resolution: {integrity: sha512-1I+RwWyS+kdv3Mv0Vmc+p0dPYH0DTRAo04HLyXReYBL9AeseDWUJyi4THuksBJcu9F0Pih69Ak150VDnqbVnXg==}
@@ -22752,7 +22752,7 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       eslint-visitor-keys: 3.4.3
 
-  '@ucp-js/sdk@0.1.0':
+  '@ucp-js/sdk@0.4.5':
     dependencies:
       zod: 3.25.76
 


### PR DESCRIPTION
The UCP library behind our agent-facing shopping API published a new version with a changed contract. This pull request teaches our Saleor adapter to speak that contract, so the storefront keeps answering UCP requests correctly. Shoppers see no difference, because the change is limited to the machine-to-machine API. It was split out of #772 so that the dependency update there can go in without waiting for this work.

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Target `main` from a short-lived change branch and use a Conventional Commit PR title.
- [ ] Test the changes locally to ensure they work as expected.
- [ ] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Verify all four Vercel project statuses: `nimara-docs`, `nimara-ecommerce`,
      `nimara-ecommerce-stripe`, and `nimara-marketplace`.
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [ ] Keep incomplete behavior disabled with a short-lived feature flag or branch-by-abstraction seam.
- [ ] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [ ] Update documentation to reflect any changes in functionality.


