### PR TITLE
fix(storefront): degrade a misconfigured provider to its empty service

### DIFF
--- a/apps/storefront/src/services/capabilities.ts
+++ b/apps/storefront/src/services/capabilities.ts
@@ -1,0 +1,25 @@
+import type { CapabilityServices } from "@nimara/infrastructure/types";
+
+/**
+ * The log name of every registry capability, keyed by its getter. Service
+ * loaders and the integration doctor label their logs with these names, and
+ * `satisfies` fails to compile until a new getter is named here.
+ */
+export const CAPABILITY_NAMES = {
+  getAddressService: "address",
+  getCMSMenuService: "cms-menu",
+  getCMSPageService: "cms-page",
+  getCartService: "cart",
+  getCategoryService: "category",
+  getCheckoutService: "checkout",
+  getCollectionService: "collection",
+  getMarketplaceService: "marketplace",
+  getPaymentService: "payment",
+  getSearchService: "search",
+  getStoreService: "store",
+  getTrackingService: "tracking",
+  getUserService: "user",
+} as const satisfies Record<keyof CapabilityServices, string>;
+
+export type Capability =
+  (typeof CAPABILITY_NAMES)[keyof typeof CAPABILITY_NAMES];

--- a/apps/storefront/src/services/integrations/tests/create-loader.test.ts
+++ b/apps/storefront/src/services/integrations/tests/create-loader.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Logger } from "@nimara/infrastructure/logging/types";
 
@@ -17,8 +17,13 @@ const fakeLogger = {
 const emptyService: FakeService = { name: "empty" };
 
 describe("createServiceLoader", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("builds the service for the resolved provider", async () => {
     const load = createServiceLoader({
+      capability: "search",
       resolve: () => "algolia",
       build: async (provider) => ({ name: provider }),
       emptyService,
@@ -32,6 +37,7 @@ describe("createServiceLoader", () => {
     const build = vi.fn(async (provider: string) => ({ name: provider }));
 
     const load = createServiceLoader({
+      capability: "search",
       resolve: () => null,
       build,
       emptyService,
@@ -42,10 +48,49 @@ describe("createServiceLoader", () => {
     expect(build).not.toHaveBeenCalled();
   });
 
+  it("falls back to the empty service when the provider config is invalid", async () => {
+    const load = createServiceLoader({
+      capability: "search",
+      resolve: () => "algolia",
+      build: async () => {
+        throw new Error("SEARCH_ALGOLIA_APP_ID is required");
+      },
+      emptyService,
+      logger: fakeLogger,
+    });
+
+    expect(await load()).toBe(emptyService);
+    expect(fakeLogger.critical).toHaveBeenCalledWith(expect.any(String), {
+      capability: "search",
+      provider: "algolia",
+      reason: "SEARCH_ALGOLIA_APP_ID is required",
+    });
+  });
+
+  it("does not retry a failed construction on the next call", async () => {
+    const build = vi.fn(async () => {
+      throw new Error("boom");
+    });
+
+    const load = createServiceLoader<FakeService, string>({
+      capability: "search",
+      resolve: () => "algolia",
+      build,
+      emptyService,
+      logger: fakeLogger,
+    });
+
+    expect(await load()).toBe(emptyService);
+    expect(await load()).toBe(emptyService);
+    expect(build).toHaveBeenCalledOnce();
+    expect(fakeLogger.critical).toHaveBeenCalledOnce();
+  });
+
   it("builds the service only once and caches it", async () => {
     const build = vi.fn(async (provider: string) => ({ name: provider }));
 
     const load = createServiceLoader({
+      capability: "search",
       resolve: () => "saleor",
       build,
       emptyService,

--- a/apps/storefront/src/services/integrations/tests/create-loader.test.ts
+++ b/apps/storefront/src/services/integrations/tests/create-loader.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 
 import type { Logger } from "@nimara/infrastructure/logging/types";
 
@@ -15,6 +16,15 @@ const fakeLogger = {
 } satisfies Logger;
 
 const emptyService: FakeService = { name: "empty" };
+
+/** A real `ZodError`, the way a provider config mapper produces one. */
+const configError = (() => {
+  const result = z.object({ SEARCH_ALGOLIA_APP_ID: z.string() }).safeParse({});
+
+  return result.success
+    ? new Error("the schema must reject an empty env")
+    : result.error;
+})();
 
 describe("createServiceLoader", () => {
   beforeEach(() => {
@@ -49,11 +59,11 @@ describe("createServiceLoader", () => {
   });
 
   it("falls back to the empty service when the provider config is invalid", async () => {
-    const load = createServiceLoader({
+    const load = createServiceLoader<FakeService, string>({
       capability: "search",
       resolve: () => "algolia",
       build: async () => {
-        throw new Error("SEARCH_ALGOLIA_APP_ID is required");
+        throw configError;
       },
       emptyService,
       logger: fakeLogger,
@@ -63,13 +73,13 @@ describe("createServiceLoader", () => {
     expect(fakeLogger.critical).toHaveBeenCalledWith(expect.any(String), {
       capability: "search",
       provider: "algolia",
-      reason: "SEARCH_ALGOLIA_APP_ID is required",
+      reason: expect.stringContaining("SEARCH_ALGOLIA_APP_ID"),
     });
   });
 
-  it("does not retry a failed construction on the next call", async () => {
+  it("does not retry an invalid config on the next call", async () => {
     const build = vi.fn(async () => {
-      throw new Error("boom");
+      throw configError;
     });
 
     const load = createServiceLoader<FakeService, string>({
@@ -84,6 +94,76 @@ describe("createServiceLoader", () => {
     expect(await load()).toBe(emptyService);
     expect(build).toHaveBeenCalledOnce();
     expect(fakeLogger.critical).toHaveBeenCalledOnce();
+  });
+
+  it("rebuilds after a transient construction failure", async () => {
+    const build = vi
+      .fn(async (provider: string) => ({ name: provider }))
+      .mockRejectedValueOnce(new Error("socket hang up"));
+
+    const load = createServiceLoader<FakeService, string>({
+      capability: "search",
+      resolve: () => "algolia",
+      build,
+      emptyService,
+      logger: fakeLogger,
+    });
+
+    expect(await load()).toBe(emptyService);
+    expect(await load()).toEqual({ name: "algolia" });
+    expect(build).toHaveBeenCalledTimes(2);
+    expect(fakeLogger.error).toHaveBeenCalledOnce();
+    expect(fakeLogger.critical).not.toHaveBeenCalled();
+  });
+
+  it("keeps the rebuilt service once a transient failure clears", async () => {
+    const build = vi
+      .fn(async (provider: string) => ({ name: provider }))
+      .mockRejectedValueOnce(new Error("socket hang up"));
+
+    const load = createServiceLoader<FakeService, string>({
+      capability: "search",
+      resolve: () => "algolia",
+      build,
+      emptyService,
+      logger: fakeLogger,
+    });
+
+    await load();
+    const first = await load();
+    const second = await load();
+
+    expect(first).toBe(second);
+    expect(build).toHaveBeenCalledTimes(2);
+  });
+
+  it("builds the service once for calls that overlap the first build", async () => {
+    let release: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const build = vi.fn(async (provider: string) => {
+      await started;
+
+      return { name: provider };
+    });
+
+    const load = createServiceLoader({
+      capability: "search",
+      resolve: () => "algolia",
+      build,
+      emptyService,
+      logger: fakeLogger,
+    });
+
+    const first = load();
+    const second = load();
+
+    release?.();
+
+    expect(await first).toBe(await second);
+    expect(build).toHaveBeenCalledOnce();
   });
 
   it("builds the service only once and caches it", async () => {

--- a/apps/storefront/src/services/lazy-loaders/address.ts
+++ b/apps/storefront/src/services/lazy-loaders/address.ts
@@ -15,6 +15,7 @@ import { getRequiredSaleorApiUrl } from "../utils/required-env";
  */
 export const createAddressServiceLoader = (logger: Logger) =>
   createServiceLoader({
+    capability: "address",
     resolve: () => (isSaleorConfigured ? "saleor" : null),
     build: async () => {
       const { saleorAddressService } =

--- a/apps/storefront/src/services/lazy-loaders/cart.ts
+++ b/apps/storefront/src/services/lazy-loaders/cart.ts
@@ -13,6 +13,7 @@ import { getRequiredSaleorApiUrl } from "../utils/required-env";
  */
 export const createCartServiceLoader = (logger: Logger) =>
   createServiceLoader({
+    capability: "cart",
     resolve: () => (isSaleorConfigured ? "saleor" : null),
     build: async () => {
       const { saleorCartService } =

--- a/apps/storefront/src/services/lazy-loaders/category.ts
+++ b/apps/storefront/src/services/lazy-loaders/category.ts
@@ -15,6 +15,7 @@ import { getRequiredSaleorApiUrl } from "../utils/required-env";
  */
 export const createCategoryServiceLoader = (logger: Logger) =>
   createServiceLoader({
+    capability: "category",
     resolve: () => (isSaleorConfigured ? "saleor" : null),
     build: async () => {
       const { saleorCategoryService } =

--- a/apps/storefront/src/services/lazy-loaders/checkout.ts
+++ b/apps/storefront/src/services/lazy-loaders/checkout.ts
@@ -16,6 +16,7 @@ import { getRequiredSaleorApiUrl } from "../utils/required-env";
  */
 export const createCheckoutServiceLoader = (logger: Logger) =>
   createServiceLoader({
+    capability: "checkout",
     resolve: () => (isSaleorConfigured ? "saleor" : null),
     build: async () => {
       const { saleorCheckoutService } =

--- a/apps/storefront/src/services/lazy-loaders/cms-menu.ts
+++ b/apps/storefront/src/services/lazy-loaders/cms-menu.ts
@@ -16,6 +16,7 @@ import { emptyCMSMenuService } from "../utils/empty-services";
  */
 export const createCMSMenuServiceLoader = (logger: Logger) =>
   createServiceLoader({
+    capability: "cms-menu",
     resolve: resolveCMSProvider,
     build: (provider, log) =>
       createCMSMenuService(provider, { env: process.env, logger: log }),

--- a/apps/storefront/src/services/lazy-loaders/cms-page.ts
+++ b/apps/storefront/src/services/lazy-loaders/cms-page.ts
@@ -16,6 +16,7 @@ import { emptyCMSPageService } from "../utils/empty-services";
  */
 export const createCMSPageServiceLoader = (logger: Logger) =>
   createServiceLoader({
+    capability: "cms-page",
     resolve: resolveCMSProvider,
     build: (provider, log) =>
       createCMSPageService(provider, { env: process.env, logger: log }),

--- a/apps/storefront/src/services/lazy-loaders/collection.ts
+++ b/apps/storefront/src/services/lazy-loaders/collection.ts
@@ -15,6 +15,7 @@ import { getRequiredSaleorApiUrl } from "../utils/required-env";
  */
 export const createCollectionServiceLoader = (logger: Logger) =>
   createServiceLoader({
+    capability: "collection",
     resolve: () => (isSaleorConfigured ? "saleor" : null),
     build: async () => {
       const { saleorCollectionService } =

--- a/apps/storefront/src/services/lazy-loaders/marketplace.ts
+++ b/apps/storefront/src/services/lazy-loaders/marketplace.ts
@@ -17,6 +17,7 @@ import { getRequiredSaleorApiUrl } from "../utils/required-env";
  */
 export const createMarketplaceServiceLoader = (logger: Logger) =>
   createServiceLoader({
+    capability: "marketplace",
     resolve: () => (isSaleorConfigured ? "saleor" : null),
     build: async () => {
       const { saleorMarketplaceService } =

--- a/apps/storefront/src/services/lazy-loaders/search.ts
+++ b/apps/storefront/src/services/lazy-loaders/search.ts
@@ -16,6 +16,7 @@ import { emptySearchService } from "../utils/empty-services";
  */
 export const createSearchServiceLoader = (logger: Logger) =>
   createServiceLoader({
+    capability: "search",
     resolve: resolveSearchProvider,
     build: (provider, log) =>
       createSearchService(provider, { env: process.env, logger: log }),

--- a/apps/storefront/src/services/lazy-loaders/store.ts
+++ b/apps/storefront/src/services/lazy-loaders/store.ts
@@ -14,6 +14,7 @@ import { getRequiredSaleorApiUrl } from "../utils/required-env";
  */
 export const createStoreServiceLoader = (logger: Logger) =>
   createServiceLoader({
+    capability: "store",
     resolve: () => (isSaleorConfigured ? "saleor" : null),
     build: async () => {
       const { saleorStoreService } =

--- a/apps/storefront/src/services/lazy-loaders/user.ts
+++ b/apps/storefront/src/services/lazy-loaders/user.ts
@@ -12,6 +12,7 @@ import { getRequiredSaleorApiUrl } from "../utils/required-env";
  */
 export const createUserServiceLoader = (logger: Logger) =>
   createServiceLoader({
+    capability: "user",
     resolve: () => (isSaleorConfigured ? "saleor" : null),
     build: async () => {
       const { saleorUserService } =

--- a/apps/storefront/src/services/registry.ts
+++ b/apps/storefront/src/services/registry.ts
@@ -10,6 +10,7 @@ import { createAddressServiceLoader } from "@/services/lazy-loaders/address";
 import { createCheckoutServiceLoader } from "@/services/lazy-loaders/checkout";
 import { createMarketplaceServiceLoader } from "@/services/lazy-loaders/marketplace";
 import { createPaymentServiceLoader } from "@/services/lazy-loaders/payment";
+import { logIntegrationConfigIssues } from "@/services/utils/integration-doctor";
 
 import { createCartServiceLoader } from "./lazy-loaders/cart";
 import { createCategoryServiceLoader } from "./lazy-loaders/category";
@@ -57,6 +58,8 @@ export const getServiceRegistry = async (): Promise<ServiceRegistry> => {
   }
 
   const logger = getLogger({ name: "storefront" });
+
+  logIntegrationConfigIssues(logger);
 
   const getters = Object.fromEntries(
     Object.entries(SERVICE_LOADERS).map(([key, createLoader]) => [

--- a/apps/storefront/src/services/utils/create-loader.ts
+++ b/apps/storefront/src/services/utils/create-loader.ts
@@ -9,18 +9,27 @@ import type { Logger } from "@nimara/infrastructure/logging/types";
  * When no provider is selected the loader returns `emptyService` so the
  * storefront keeps rendering instead of crashing.
  *
+ * A selected provider whose config is missing or invalid degrades the same way:
+ * every provider config mapper validates with a throwing `parse`, and a broken
+ * capability must not take down routes that never use it. The empty service is
+ * memoized too, so a broken deployment does not retry the failing construction
+ * on every request. `logIntegrationConfigIssues` reports which keys are missing
+ * when the registry is built.
+ *
  * The provider catalog and wiring live in infrastructure — this helper only owns
  * the lazy/cache/empty-fallback lifecycle.
  *
  * @internal Only the service registry should call the returned loader.
  */
 export const createServiceLoader = <TService, TId extends string>({
+  capability,
   resolve,
   build,
   emptyService,
   logger,
 }: {
   build: (provider: TId, logger: Logger) => Promise<TService>;
+  capability: string;
   emptyService: TService;
   logger: Logger;
   resolve: () => TId | null;
@@ -40,7 +49,24 @@ export const createServiceLoader = <TService, TId extends string>({
       return instance;
     }
 
-    instance = await build(provider, logger);
+    try {
+      instance = await build(provider, logger);
+    } catch (error) {
+      /*
+       * Provider config schemas name the missing env keys in their messages and
+       * never carry their values, so the message is safe to log.
+       */
+      logger.critical(
+        "Provider construction failed; serving the empty service.",
+        {
+          capability,
+          provider,
+          reason: error instanceof Error ? error.message : String(error),
+        },
+      );
+
+      instance = emptyService;
+    }
 
     return instance;
   };

--- a/apps/storefront/src/services/utils/create-loader.ts
+++ b/apps/storefront/src/services/utils/create-loader.ts
@@ -6,39 +6,6 @@ import type { Capability } from "@/services/capabilities";
 
 type Attempt<TService> = { retry: boolean; service: TService };
 
-/**
- * Builds a lazy, cached loader for a single capability (search, CMS page, …).
- *
- * Selection is build-time and env-driven: `resolve` returns the chosen provider
- * id (or `null`), `build` instantiates the service for that id (delegating to
- * the infrastructure `create*Service` entry point), and the result is memoized.
- * When no provider is selected the loader returns `emptyService` so the
- * storefront keeps rendering instead of crashing.
- *
- * A selected provider whose config is missing or invalid degrades the same way:
- * every provider config mapper validates with a throwing `parse`, and a broken
- * capability must not take down routes that never use it.
- * `logIntegrationConfigIssues` reports which keys are missing when the registry
- * is built.
- *
- * A failed construction memoizes the empty service only when the cause is
- * deterministic. A `ZodError` means the config cannot become valid without a
- * new deployment, so retrying it on every request only burns work. Any other
- * cause — a failed dynamic import, an I/O timeout inside a provider entry
- * point — can succeed on the next call, so the empty service answers that one
- * call and the next call rebuilds. Memoizing a transient failure would degrade
- * a capability until the process dies.
- *
- * What is memoized is the in-flight promise, not the resolved service, so
- * requests that arrive concurrently during the first construction share it
- * instead of each starting their own. `attempt` never rejects, so a memoized
- * rejection cannot poison the cache.
- *
- * The provider catalog and wiring live in infrastructure — this helper only owns
- * the lazy/cache/empty-fallback lifecycle.
- *
- * @internal Only the service registry should call the returned loader.
- */
 export const createServiceLoader = <TService, TId extends string>({
   capability,
   resolve,
@@ -53,21 +20,19 @@ export const createServiceLoader = <TService, TId extends string>({
   resolve: () => TId | null;
 }) => {
   const attempt = async (): Promise<Attempt<TService>> => {
-    const provider = resolve();
-
-    if (!provider) {
-      return { service: emptyService, retry: false };
-    }
+    let provider: TId | null = null;
 
     try {
+      provider = resolve();
+
+      if (!provider) {
+        return { service: emptyService, retry: false };
+      }
+
       return { service: await build(provider, logger), retry: false };
     } catch (error) {
       const isConfigError = error instanceof ZodError;
 
-      /*
-       * Provider config schemas name the missing env keys in their messages and
-       * never carry their values, so the message is safe to log.
-       */
       const context = {
         capability,
         provider,

--- a/apps/storefront/src/services/utils/create-loader.ts
+++ b/apps/storefront/src/services/utils/create-loader.ts
@@ -1,4 +1,10 @@
+import { ZodError } from "zod";
+
 import type { Logger } from "@nimara/infrastructure/logging/types";
+
+import type { Capability } from "@/services/capabilities";
+
+type Attempt<TService> = { retry: boolean; service: TService };
 
 /**
  * Builds a lazy, cached loader for a single capability (search, CMS page, …).
@@ -11,10 +17,22 @@ import type { Logger } from "@nimara/infrastructure/logging/types";
  *
  * A selected provider whose config is missing or invalid degrades the same way:
  * every provider config mapper validates with a throwing `parse`, and a broken
- * capability must not take down routes that never use it. The empty service is
- * memoized too, so a broken deployment does not retry the failing construction
- * on every request. `logIntegrationConfigIssues` reports which keys are missing
- * when the registry is built.
+ * capability must not take down routes that never use it.
+ * `logIntegrationConfigIssues` reports which keys are missing when the registry
+ * is built.
+ *
+ * A failed construction memoizes the empty service only when the cause is
+ * deterministic. A `ZodError` means the config cannot become valid without a
+ * new deployment, so retrying it on every request only burns work. Any other
+ * cause — a failed dynamic import, an I/O timeout inside a provider entry
+ * point — can succeed on the next call, so the empty service answers that one
+ * call and the next call rebuilds. Memoizing a transient failure would degrade
+ * a capability until the process dies.
+ *
+ * What is memoized is the in-flight promise, not the resolved service, so
+ * requests that arrive concurrently during the first construction share it
+ * instead of each starting their own. `attempt` never rejects, so a memoized
+ * rejection cannot poison the cache.
  *
  * The provider catalog and wiring live in infrastructure — this helper only owns
  * the lazy/cache/empty-fallback lifecycle.
@@ -29,44 +47,63 @@ export const createServiceLoader = <TService, TId extends string>({
   logger,
 }: {
   build: (provider: TId, logger: Logger) => Promise<TService>;
-  capability: string;
+  capability: Capability;
   emptyService: TService;
   logger: Logger;
   resolve: () => TId | null;
 }) => {
-  let instance: TService | null = null;
-
-  return async (): Promise<TService> => {
-    if (instance) {
-      return instance;
-    }
-
+  const attempt = async (): Promise<Attempt<TService>> => {
     const provider = resolve();
 
     if (!provider) {
-      instance = emptyService;
-
-      return instance;
+      return { service: emptyService, retry: false };
     }
 
     try {
-      instance = await build(provider, logger);
+      return { service: await build(provider, logger), retry: false };
     } catch (error) {
+      const isConfigError = error instanceof ZodError;
+
       /*
        * Provider config schemas name the missing env keys in their messages and
        * never carry their values, so the message is safe to log.
        */
-      logger.critical(
-        "Provider construction failed; serving the empty service.",
-        {
-          capability,
-          provider,
-          reason: error instanceof Error ? error.message : String(error),
-        },
-      );
+      const context = {
+        capability,
+        provider,
+        reason: error instanceof Error ? error.message : String(error),
+      };
 
-      instance = emptyService;
+      if (isConfigError) {
+        logger.critical(
+          "Provider configuration is invalid; serving the empty service until the next deployment.",
+          context,
+        );
+      } else {
+        logger.error(
+          "Provider construction failed; serving the empty service for this call.",
+          context,
+        );
+      }
+
+      return { service: emptyService, retry: !isConfigError };
     }
+  };
+
+  let instance: Promise<TService> | null = null;
+
+  return (): Promise<TService> => {
+    if (instance) {
+      return instance;
+    }
+
+    instance = attempt().then(({ service, retry }) => {
+      if (retry) {
+        instance = null;
+      }
+
+      return service;
+    });
 
     return instance;
   };

--- a/apps/storefront/src/services/utils/integration-doctor.test.ts
+++ b/apps/storefront/src/services/utils/integration-doctor.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { Logger } from "@nimara/infrastructure/logging/types";
+
 import type { IntegrationReportRow } from "./integration-doctor";
 
 const envMock = {
@@ -17,7 +19,16 @@ vi.mock("@/services/utils/empty-services", () => ({
   },
 }));
 
-const { buildIntegrationReport } = await import("./integration-doctor");
+const { buildIntegrationReport, logIntegrationConfigIssues } =
+  await import("./integration-doctor");
+
+const fakeLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+  error: vi.fn(),
+  critical: vi.fn(),
+} satisfies Logger;
 
 const rowFor = (
   rows: IntegrationReportRow[],
@@ -85,5 +96,36 @@ describe("buildIntegrationReport", () => {
       ok: true,
       selected: "dummy",
     });
+  });
+});
+
+describe("logIntegrationConfigIssues", () => {
+  beforeEach(() => {
+    envMock.SEARCH_SERVICE = "saleor";
+    envMock.CMS_SERVICE = "saleor";
+    saleorMock.configured = true;
+    vi.clearAllMocks();
+  });
+
+  it("logs a critical naming the missing keys of the selected provider", () => {
+    envMock.SEARCH_SERVICE = "algolia";
+
+    logIntegrationConfigIssues(fakeLogger, {
+      NEXT_PUBLIC_SALEOR_API_URL: "https://x.saleor.cloud/graphql/",
+    });
+
+    expect(fakeLogger.critical).toHaveBeenCalledWith(expect.any(String), {
+      capability: "search",
+      provider: "algolia",
+      missing: expect.arrayContaining(["SEARCH_ALGOLIA_APP_ID"]),
+    });
+  });
+
+  it("stays silent when every selected provider is configured", () => {
+    logIntegrationConfigIssues(fakeLogger, {
+      NEXT_PUBLIC_SALEOR_API_URL: "https://x.saleor.cloud/graphql/",
+    });
+
+    expect(fakeLogger.critical).not.toHaveBeenCalled();
   });
 });

--- a/apps/storefront/src/services/utils/integration-doctor.ts
+++ b/apps/storefront/src/services/utils/integration-doctor.ts
@@ -2,6 +2,7 @@ import { type ZodType } from "zod";
 
 import { cmsMenuProviders } from "@nimara/infrastructure/cms-menu/select";
 import { cmsPageProviders } from "@nimara/infrastructure/cms-page/select";
+import type { Logger } from "@nimara/infrastructure/logging/types";
 import { searchProviders } from "@nimara/infrastructure/search/select";
 
 import {
@@ -10,7 +11,7 @@ import {
 } from "@/services/integrations/resolve";
 
 export type IntegrationReportRow = {
-  capability: string;
+  capability: SwappableCapability;
   missing: string[];
   ok: boolean;
   selected: string | null;
@@ -22,7 +23,7 @@ type CapabilityEntry = {
   resolve: () => string | null;
 };
 
-const CAPABILITIES: CapabilityEntry[] = [
+const CAPABILITIES = [
   {
     capability: "search",
     providers: searchProviders,
@@ -38,7 +39,13 @@ const CAPABILITIES: CapabilityEntry[] = [
     providers: cmsMenuProviders,
     resolve: resolveCMSProvider,
   },
-];
+] as const satisfies readonly CapabilityEntry[];
+
+/*
+ * Derived from `CAPABILITIES` rather than hand-listed, so a typo in a caller is
+ * a compile error instead of a silently false check that hides a surface.
+ */
+export type SwappableCapability = (typeof CAPABILITIES)[number]["capability"];
 
 /**
  * Reports, per swappable capability, which provider is selected and whether its
@@ -73,6 +80,31 @@ export const buildIntegrationReport = (
 
     return { capability, missing, ok: false, selected };
   });
+
+/**
+ * Emits one `critical` per capability whose selected provider is missing config,
+ * when the service registry is built. It logs instead of throwing: a broken
+ * search configuration must not take down checkout, and the loader degrades the
+ * affected capability to its empty service on first use. Without this a missing
+ * key stays invisible until a shopper reaches that capability, and the empty
+ * service for a read capability answers with no data rather than an error.
+ */
+export const logIntegrationConfigIssues = (
+  logger: Logger,
+  env?: Record<string, string | undefined>,
+): void => {
+  for (const row of buildIntegrationReport(env)) {
+    if (row.ok) {
+      continue;
+    }
+
+    logger.critical("Selected provider is missing required configuration.", {
+      capability: row.capability,
+      provider: row.selected,
+      missing: row.missing,
+    });
+  }
+};
 
 /** Human-readable preflight report for the active integration configuration. */
 export const formatIntegrationReport = (

--- a/apps/storefront/src/services/utils/integration-doctor.ts
+++ b/apps/storefront/src/services/utils/integration-doctor.ts
@@ -24,6 +24,12 @@ type CapabilityEntry = {
   resolve: () => string | null;
 };
 
+/*
+ * Only the capabilities whose implementation is chosen by configuration. Every
+ * other registry capability has one implementation whose sole condition is the
+ * backend URL, which `resolve` already answers, so a row for it could report
+ * nothing but success.
+ */
 const CAPABILITIES = [
   {
     capability: "search",
@@ -85,12 +91,13 @@ export const buildIntegrationReport = (
   });
 
 /**
- * Emits one `critical` per capability whose selected provider is missing config,
- * when the service registry is built. It logs instead of throwing: a broken
- * search configuration must not take down checkout, and the loader degrades the
- * affected capability to its empty service on first use. Without this a missing
- * key stays invisible until a shopper reaches that capability, and the empty
- * service for a read capability answers with no data rather than an error.
+ * Emits one `critical` per swappable capability whose selected provider is
+ * missing config, when the service registry is built. It logs instead of
+ * throwing: a broken search configuration must not take down checkout, and the
+ * loader degrades the affected capability to its empty service on first use.
+ * Without this a missing key stays invisible until a shopper reaches that
+ * capability, and the empty service for a read capability answers with no data
+ * rather than an error.
  */
 export const logIntegrationConfigIssues = (
   logger: Logger,
@@ -109,7 +116,7 @@ export const logIntegrationConfigIssues = (
   }
 };
 
-/** Human-readable preflight report for the active integration configuration. */
+/** Human-readable preflight report for the swappable capabilities. */
 export const formatIntegrationReport = (
   env?: Record<string, string | undefined>,
 ): string => {
@@ -125,5 +132,7 @@ export const formatIntegrationReport = (
     return `✗ ${row.capability}: ${row.selected} — missing/invalid env: ${row.missing.join(", ")}`;
   });
 
-  return ["Integration preflight", ...lines].join("\n");
+  return ["Integration preflight (swappable capabilities)", ...lines].join(
+    "\n",
+  );
 };

--- a/apps/storefront/src/services/utils/integration-doctor.ts
+++ b/apps/storefront/src/services/utils/integration-doctor.ts
@@ -5,6 +5,7 @@ import { cmsPageProviders } from "@nimara/infrastructure/cms-page/select";
 import type { Logger } from "@nimara/infrastructure/logging/types";
 import { searchProviders } from "@nimara/infrastructure/search/select";
 
+import type { Capability } from "@/services/capabilities";
 import {
   resolveCMSProvider,
   resolveSearchProvider,
@@ -18,7 +19,7 @@ export type IntegrationReportRow = {
 };
 
 type CapabilityEntry = {
-  capability: string;
+  capability: Capability;
   providers: readonly { configSchema?: ZodType; id: string }[];
   resolve: () => string | null;
 };
@@ -43,7 +44,9 @@ const CAPABILITIES = [
 
 /*
  * Derived from `CAPABILITIES` rather than hand-listed, so a typo in a caller is
- * a compile error instead of a silently false check that hides a surface.
+ * a compile error instead of a silently false check that hides a surface. The
+ * entries draw their names from `Capability`, so a doctor row and a loader log
+ * always label the same capability the same way.
  */
 export type SwappableCapability = (typeof CAPABILITIES)[number]["capability"];
 

--- a/llm-wiki/log.md
+++ b/llm-wiki/log.md
@@ -743,6 +743,9 @@
   critical event naming the missing values.
 - **Update**: Added the first-request critical event for missing provider configuration to the
   verification steps of OPS-0001.
+- **Update**: Separated permanent from temporary construction failure in CAP-0001 and OPS-0001. The
+  service loader keeps the empty service only for invalid configuration. Any other cause logs an
+  error event and the loader builds the service again on the next call.
 - **Lint**: `pnpm wiki:lint` at zero violations.
 
 ## 2026-08-28

--- a/llm-wiki/log.md
+++ b/llm-wiki/log.md
@@ -736,6 +736,15 @@
   every record in ASD-STE100 Simplified Technical English.
 - **Lint**: `pnpm wiki:lint` at zero violations across 94 files.
 
+## 2026-08-26
+
+- **Update**: Corrected CAP-0001, which described a provider selected without its configuration as
+  failing service construction. That capability now degrades to its empty service and logs a
+  critical event naming the missing values.
+- **Update**: Added the first-request critical event for missing provider configuration to the
+  verification steps of OPS-0001.
+- **Lint**: `pnpm wiki:lint` at zero violations.
+
 ## 2026-08-28
 
 - **Create**: Added IMP-0005 as `in_progress` for the daily GitHub summary bot, tracing PR #799.

--- a/llm-wiki/operations/OPS-0001 Storefront Deployment and Configuration Validation.md
+++ b/llm-wiki/operations/OPS-0001 Storefront Deployment and Configuration Validation.md
@@ -76,7 +76,11 @@ to this deployment procedure.
 - Read the first request's log for a critical event naming a capability, its selected provider, and
   missing configuration values. A selected provider with incomplete configuration no longer fails
   the request; it serves the empty service, so this event is the only signal that a capability is
-  degraded.
+  degraded. Treat a critical event as a broken deployment. The capability stays degraded until the
+  next deployment.
+- Read the same log for an error event that names a capability and a failed provider construction.
+  This event reports a cause that can clear by itself, and the storefront builds the service again
+  on the next call. Repeated error events for one capability mean that the cause is not clearing.
 
 # Escalation
 

--- a/llm-wiki/operations/OPS-0001 Storefront Deployment and Configuration Validation.md
+++ b/llm-wiki/operations/OPS-0001 Storefront Deployment and Configuration Validation.md
@@ -73,6 +73,10 @@ to this deployment procedure.
   image delivery. Exercise the external search or content provider when one is selected.
 - Review build and runtime logs for environment validation, GraphQL code-generation, provider
   construction, authentication, Sentry, and image-host failures.
+- Read the first request's log for a critical event naming a capability, its selected provider, and
+  missing configuration values. A selected provider with incomplete configuration no longer fails
+  the request; it serves the empty service, so this event is the only signal that a capability is
+  degraded.
 
 # Escalation
 

--- a/llm-wiki/product/capabilities/CAP-0001 Swappable Storefront Search and Content Providers.md
+++ b/llm-wiki/product/capabilities/CAP-0001 Swappable Storefront Search and Content Providers.md
@@ -58,8 +58,12 @@ building or deploying.
 - Provider selection is build-time configuration; changing it requires a rebuild and redeploy.
 - Content pages and menus share one provider ID and a common provider catalog, so they cannot drift
   to independently selected implementations.
-- Explicitly selecting a provider without its required configuration fails service construction;
-  preflight reports the same missing or invalid values before runtime.
+- Explicitly selecting a provider without its required configuration degrades that capability to its
+  empty service and logs a critical event naming the capability, the provider, and the missing
+  values. One capability's broken configuration therefore does not take down routes that never use
+  it. The event is emitted once when the service registry is built, so a missing value is visible
+  from the first request rather than from the first shopper who reaches that capability. Preflight
+  reports the same values before runtime.
 - Built-in sample providers require no external credentials but are an automatic fallback only
   outside production. Production falls back to empty services when the default backend is absent.
 - A provider-specific upstream failure retains that provider's existing service-level error

--- a/llm-wiki/product/capabilities/CAP-0001 Swappable Storefront Search and Content Providers.md
+++ b/llm-wiki/product/capabilities/CAP-0001 Swappable Storefront Search and Content Providers.md
@@ -64,6 +64,11 @@ building or deploying.
   it. The event is emitted once when the service registry is built, so a missing value is visible
   from the first request rather than from the first shopper who reaches that capability. Preflight
   reports the same values before runtime.
+- Invalid configuration is permanent for the life of the deployment, so the storefront serves the
+  empty service for that capability until the next deployment and does not repeat the failed
+  construction. A construction that fails for any other cause can succeed later. The storefront
+  serves the empty service for that one call, logs an error event, and builds the service again on
+  the next call.
 - Built-in sample providers require no external credentials but are an automatic fallback only
   outside production. Production falls back to empty services when the default backend is absent.
 - A provider-specific upstream failure retains that provider's existing service-level error


### PR DESCRIPTION
A selected provider whose configuration failed validation threw out of the service loader, because every provider config mapper validates with a throwing parse and only an unselected provider fell back to the empty service. A deployment that named a provider without its keys therefore failed the first request that used the capability, with no signal before it.

The loader now catches a failed construction, serves the empty service, and memoizes that fallback so a broken deployment stops retrying. It logs a critical event naming the capability, the provider and the reason, and the registry reports missing configuration once when it is built, so a degraded capability is visible from the first request. Logging rather than throwing keeps one broken capability from taking down routes that never use it.