### PR TITLE
feat: Ask whether an app serves one Saleor or many

### DIFF
--- a/templates/app/README.md
+++ b/templates/app/README.md
@@ -21,6 +21,11 @@ pnpm dev
 Set at least `ENVIRONMENT` and `ALLOWED_DOMAINS` — an empty allow list admits
 no Saleor at all, which is the safe default but installs nothing.
 
+A single-tenant app names one concrete domain there and reads it back as
+`SALEOR_DOMAIN`, for work that arrives with no request. A multi-tenant one has
+no such field: it takes the tenant from whichever middleware verified the
+caller.
+
 ## Layout
 
 ```

--- a/turbo/generators/config.ts
+++ b/turbo/generators/config.ts
@@ -8,6 +8,8 @@ import { createApp } from "./src/create-app.ts";
 import {
   BUILD_TARGETS,
   type BuildTarget,
+  TENANCIES,
+  type Tenancy,
   toDirectoryName,
   validateName,
 } from "./src/names.ts";
@@ -17,6 +19,7 @@ type Answers = {
   name: string;
   port: string;
   target: BuildTarget;
+  tenancy: Tenancy;
   turbo: { paths: { root: string } };
 };
 
@@ -57,6 +60,22 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
           input.trim().length > 0 || "A description is required.",
       },
       {
+        choices: [
+          {
+            name: "multi — installable by many Saleor instances",
+            value: "multi",
+          },
+          {
+            name: "single — serves the one Saleor named in ALLOWED_DOMAINS",
+            value: "single",
+          },
+        ] satisfies { name: string; value: Tenancy }[],
+        default: TENANCIES[0],
+        message: "How many Saleor instances does it serve?",
+        name: "tenancy",
+        type: "list",
+      },
+      {
         choices: [...BUILD_TARGETS],
         default: "vercel",
         message: "What is the deployment target?",
@@ -74,7 +93,8 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
     ],
     actions: [
       async (answers) => {
-        const { description, name, port, target, turbo } = answers as Answers;
+        const { description, name, port, target, tenancy, turbo } =
+          answers as Answers;
 
         const destination = await createApp({
           description,
@@ -82,6 +102,7 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
           port,
           root: turbo.paths.root,
           target,
+          tenancy,
         });
 
         const pnpm = run(turbo.paths.root);

--- a/turbo/generators/src/create-app.test.ts
+++ b/turbo/generators/src/create-app.test.ts
@@ -21,13 +21,17 @@ const write = async (path: string, contents: string) => {
   await writeFile(path, contents);
 };
 
-const generate = (target: "node" | "vercel" = "vercel") =>
+const generate = ({
+  target = "vercel",
+  tenancy = "multi",
+}: { target?: "node" | "vercel"; tenancy?: "multi" | "single" } = {}) =>
   createApp({
     description: "Keeps a feed in step with Saleor",
     name: "feed-sync",
     port: "8010",
     root,
     target,
+    tenancy,
   });
 
 describe("create-app", () => {
@@ -42,10 +46,20 @@ describe("create-app", () => {
     await write(join(template(), "README.md"), "# app-template\nPort 8000.\n");
     await write(
       join(template(), ".env.example"),
-      "BUILD_TARGET=vercel\nPORT=8000\n",
+      "BUILD_TARGET=vercel\n" +
+        "# Comma-separated Saleor domains allowed to install the app, e.g.\n" +
+        "# store.saleor.cloud. Empty allows none. Wildcards (`*`, `*.saleor.cloud`)\n" +
+        "# widen it and belong in local development only.\n" +
+        "ALLOWED_DOMAINS=\n" +
+        "PORT=8000\n",
     );
     await write(join(template(), "vercel.json"), '{"framework":"hono"}');
     await write(join(template(), "src", "index.ts"), "export const a = 1;\n");
+    await write(
+      join(template(), "src", "services", "handler", "config.ts"),
+      'import { prepareServiceConfig } from "@nimara/lib/config/service";\n' +
+        "export const APP_CONFIG = prepareServiceConfig({});\n",
+    );
   });
 
   afterEach(() => rm(root, { force: true, recursive: true }));
@@ -84,8 +98,8 @@ describe("create-app", () => {
     expect(await readFile(join(destination, "README.md"), "utf8")).toBe(
       "# feed-sync\nPort 8010.\n",
     );
-    expect(await readFile(join(destination, ".env.example"), "utf8")).toBe(
-      "BUILD_TARGET=vercel\nPORT=8010\n",
+    expect(await readFile(join(destination, ".env.example"), "utf8")).toContain(
+      "PORT=8010",
     );
   });
 
@@ -97,6 +111,7 @@ describe("create-app", () => {
       port: "8010",
       root,
       target: "vercel",
+      tenancy: "multi",
     });
 
     // then `--args` skips the prompt that would have filtered it.
@@ -124,7 +139,7 @@ describe("create-app", () => {
 
   it("leaves Vercel's config behind for an app deployed elsewhere", async () => {
     // when
-    const destination = await generate("node");
+    const destination = await generate({ target: "node" });
 
     // then
     await expect(
@@ -133,6 +148,42 @@ describe("create-app", () => {
     expect(await readFile(join(destination, ".env.example"), "utf8")).toContain(
       "BUILD_TARGET=node",
     );
+  });
+
+  it("calls the single-tenant helper when the app serves one Saleor", async () => {
+    // when
+    const destination = await generate({ tenancy: "single" });
+    const config = await readFile(
+      join(destination, "src", "services", "handler", "config.ts"),
+      "utf8",
+    );
+
+    // then the generated file names the helper it calls, and that helper is
+    // what publishes `SALEOR_DOMAIN`.
+    expect(config).toContain("prepareSingleTenantServiceConfig");
+    expect(config).not.toMatch(/\bprepareServiceConfig\b/);
+  });
+
+  it("tells a single-tenant app it may name only one domain", async () => {
+    // when
+    const destination = await generate({ tenancy: "single" });
+    const env = await readFile(join(destination, ".env.example"), "utf8");
+
+    // then
+    expect(env).toContain("Exactly one");
+    expect(env).not.toContain("Wildcards");
+  });
+
+  it("leaves a multi-tenant app on the shared helper", async () => {
+    // when
+    const destination = await generate();
+    const config = await readFile(
+      join(destination, "src", "services", "handler", "config.ts"),
+      "utf8",
+    );
+
+    // then
+    expect(config).not.toContain("prepareSingleTenantServiceConfig");
   });
 
   it("refuses to write over an app that already exists", async () => {

--- a/turbo/generators/src/create-app.ts
+++ b/turbo/generators/src/create-app.ts
@@ -5,6 +5,7 @@ import {
   type BuildTarget,
   TEMPLATE_NAME,
   TEMPLATE_PORT,
+  type Tenancy,
   toDirectoryName,
 } from "./names.ts";
 
@@ -24,10 +25,48 @@ export type CreateAppInput = {
   port: string;
   root: string;
   target: BuildTarget;
+  tenancy: Tenancy;
 };
 
 // An app deployed elsewhere should not carry another platform's config.
 const TARGET_ONLY = new Set(["vercel.json"]);
+
+const ALLOWED_DOMAINS_DOC = {
+  multi: `# Comma-separated Saleor domains allowed to install the app, e.g.
+# store.saleor.cloud. Empty allows none. Wildcards (\`*\`, \`*.saleor.cloud\`)
+# widen it and belong in local development only.`,
+  single: `# The one Saleor this app serves, e.g. store.saleor.cloud. Exactly one
+# concrete domain: a wildcard names no host, and this app has to know which
+# Saleor it is working with when nothing is asking it.`,
+};
+
+/**
+ * A single-tenant app calls a different helper, which is what publishes
+ * `SALEOR_DOMAIN`. Rewritten rather than templated so the generated file names
+ * the helper it actually calls.
+ */
+const applyTenancy = async ({
+  destination,
+  tenancy,
+}: {
+  destination: string;
+  tenancy: Tenancy;
+}) => {
+  if (tenancy === "multi") {
+    return;
+  }
+
+  const path = join(destination, "src", "services", "handler", "config.ts");
+  const contents = await readFile(path, "utf8");
+
+  await writeFile(
+    path,
+    contents.replaceAll(
+      "prepareServiceConfig",
+      "prepareSingleTenantServiceConfig",
+    ),
+  );
+};
 
 const copyTemplate = ({
   destination,
@@ -86,11 +125,13 @@ const rewriteText = async ({
   name,
   port,
   target,
+  tenancy,
 }: {
   file: string;
   name: string;
   port: string;
   target: BuildTarget;
+  tenancy: Tenancy;
 }) => {
   const contents = await readFile(file, "utf8");
 
@@ -99,7 +140,8 @@ const rewriteText = async ({
     contents
       .replaceAll(TEMPLATE_NAME, name)
       .replaceAll(TEMPLATE_PORT, port)
-      .replace(/^BUILD_TARGET=.*$/m, `BUILD_TARGET=${target}`),
+      .replace(/^BUILD_TARGET=.*$/m, `BUILD_TARGET=${target}`)
+      .replace(ALLOWED_DOMAINS_DOC.multi, ALLOWED_DOMAINS_DOC[tenancy]),
   );
 };
 
@@ -110,6 +152,7 @@ export const createApp = async ({
   port,
   root,
   target,
+  tenancy,
 }: CreateAppInput) => {
   // `--args` skips the prompt that would have filtered this.
   const appName = toDirectoryName(name);
@@ -134,8 +177,11 @@ export const createApp = async ({
       name: appName,
       port,
       target,
+      tenancy,
     });
   }
+
+  await applyTenancy({ destination, tenancy });
 
   return destination;
 };

--- a/turbo/generators/src/names.ts
+++ b/turbo/generators/src/names.ts
@@ -20,3 +20,7 @@ export const validateName = (value: string) =>
 export const BUILD_TARGETS = ["vercel", "node"] as const;
 
 export type BuildTarget = (typeof BUILD_TARGETS)[number];
+
+export const TENANCIES = ["multi", "single"] as const;
+
+export type Tenancy = (typeof TENANCIES)[number];


### PR DESCRIPTION
Every generated app was multi-tenant, and choosing otherwise meant knowing
`prepareSingleTenantServiceConfig` exists and going to find it. The generator
asks instead, right after the description.

```
How many Saleor instances does it serve?
  multi  — installable by many Saleor instances       (default)
  single — serves the one Saleor named in ALLOWED_DOMAINS
```

`single` rewrites the call in the app's `config.ts` rather than aliasing it, so
the generated file names the helper it runs, and rewrites the note above
`ALLOWED_DOMAINS` to say one concrete domain instead of describing wildcards.

## Why it is worth a prompt

The difference is load-bearing. A single-tenant app reads `SALEOR_DOMAIN` back
— for work that arrives with no request, a cron or a queue consumer — and a
multi-tenant one has no such field.

Generated both and checked the same line in each:

```
single-app  APP_CONFIG.SALEOR_DOMAIN   typechecks
multi-app   APP_CONFIG.SALEOR_DOMAIN   error TS2339: Property 'SALEOR_DOMAIN'
                                       does not exist on type '{ APP_ID: ... }'
```

So growing into multiple tenants is a compile error at every caller that
assumed one, rather than a silent `undefined` at runtime.

Generator tests: 10, three of them new — the helper is swapped, the old name is
gone, and the multi-tenant path is left alone.

<!-- Please mention all relevant issue numbers. -->

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Target `main` from a short-lived change branch and use a Conventional Commit PR title.
- [ ] Test the changes locally to ensure they work as expected.
- [ ] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Verify all four Vercel project statuses: `nimara-docs`, `nimara-ecommerce`,
      `nimara-ecommerce-stripe`, and `nimara-marketplace`.
- [ ] Include new tests for any new functionality or significant changes.
- [ ] Ensure that tests cover edge cases and potential failure points.
- [ ] Keep incomplete behavior disabled with a short-lived feature flag or branch-by-abstraction seam.
- [ ] Document the impact of the changes on the system, including potential risks and benefits.
- [ ] Provide a rollback plan in case the changes introduce critical issues.
- [ ] Update documentation to reflect any changes in functionality.


