### PR TITLE
feat(ci): post a daily GitHub summary to Slack

### DIFF
--- a/.github/scripts/daily-summary.mjs
+++ b/.github/scripts/daily-summary.mjs
@@ -1,0 +1,355 @@
+/**
+ * Collects the GitHub activity since the previous daily and posts one Block Kit
+ * message to a Slack Incoming Webhook.
+ *
+ * Runs on plain Node with no dependencies so the workflow can skip `pnpm install`.
+ */
+
+const GITHUB_API = "https://api.github.com";
+const MAX_LIST_ITEMS = 10;
+const STALE_PR_DAYS = 2;
+const DEFAULT_LOOKBACK_HOURS = 24;
+const MONDAY_LOOKBACK_HOURS = 72;
+const SLACK_SECTION_LIMIT = 2900;
+
+/**
+ * Dependabot security runs report as `dynamic`. They are not the team's CI and
+ * would bury a real red build on main.
+ */
+const REPORTED_RUN_EVENTS = new Set([
+  "push",
+  "workflow_run",
+  "schedule",
+  "workflow_dispatch",
+]);
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+/**
+ * Monday must reach back over the weekend, otherwise Friday afternoon work is
+ * never reported.
+ */
+export function resolveLookbackHours(now, override) {
+  const parsed = Number(override);
+
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return parsed;
+  }
+
+  return now.getUTCDay() === 1 ? MONDAY_LOOKBACK_HOURS : DEFAULT_LOOKBACK_HOURS;
+}
+
+export function escapeMrkdwn(text) {
+  return String(text)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+export function formatAge(isoDate, now) {
+  const elapsed = now.getTime() - new Date(isoDate).getTime();
+
+  if (elapsed >= DAY_MS) {
+    const days = Math.floor(elapsed / DAY_MS);
+
+    return days === 1 ? "1 dzień" : `${days} dni`;
+  }
+
+  return `${Math.max(0, Math.floor(elapsed / HOUR_MS))} godz.`;
+}
+
+function link(url, label) {
+  return `<${url}|${escapeMrkdwn(label)}>`;
+}
+
+function bulletList(lines) {
+  const shown = lines.slice(0, MAX_LIST_ITEMS);
+  const hidden = lines.length - shown.length;
+
+  if (hidden > 0) {
+    shown.push(`_…i ${hidden} więcej_`);
+  }
+
+  return shown.join("\n").slice(0, SLACK_SECTION_LIMIT);
+}
+
+function section(text) {
+  return { type: "section", text: { type: "mrkdwn", text } };
+}
+
+async function githubRequest(path, token) {
+  const response = await fetch(`${GITHUB_API}${path}`, {
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${token}`,
+      "x-github-api-version": "2022-11-28",
+    },
+  });
+
+  if (!response.ok) {
+    const body = (await response.text()).slice(0, 200);
+
+    throw new Error(`GitHub ${response.status} for ${path}: ${body}`);
+  }
+
+  return response.json();
+}
+
+function search(repo, token, query) {
+  const q = encodeURIComponent(`repo:${repo} ${query}`);
+
+  return githubRequest(
+    `/search/issues?q=${q}&per_page=50&sort=updated&order=desc`,
+    token,
+  ).then((result) => result.items ?? []);
+}
+
+/**
+ * Keep the newest failure per workflow and commit. A retried run adds nothing new.
+ */
+function dedupeRuns(runs) {
+  const newest = new Map();
+
+  for (const run of runs) {
+    const key = `${run.name}@${run.head_sha}`;
+
+    if (!newest.has(key)) {
+      newest.set(key, run);
+    }
+  }
+
+  return [...newest.values()];
+}
+
+async function collect({ repo, token, since }) {
+  const sinceQuery = since.toISOString().replace(/\.\d{3}Z$/, "Z");
+
+  const [
+    merged,
+    toReview,
+    approved,
+    runs,
+    openedIssues,
+    closedIssues,
+    releases,
+  ] = await Promise.all([
+    search(repo, token, `is:pr is:merged merged:>=${sinceQuery}`),
+    search(repo, token, "is:pr is:open draft:false review:none"),
+    search(repo, token, "is:pr is:open draft:false review:approved"),
+    githubRequest(
+      `/repos/${repo}/actions/runs?branch=main&status=failure&per_page=20`,
+      token,
+    ),
+    search(repo, token, `is:issue created:>=${sinceQuery}`),
+    search(repo, token, `is:issue closed:>=${sinceQuery}`),
+    githubRequest(`/repos/${repo}/releases?per_page=5`, token),
+  ]);
+
+  return {
+    merged,
+    toReview,
+    approved,
+    failedRuns: dedupeRuns(
+      (runs.workflow_runs ?? []).filter(
+        (run) =>
+          new Date(run.created_at) >= since &&
+          REPORTED_RUN_EVENTS.has(run.event),
+      ),
+    ),
+    openedIssues,
+    closedIssues,
+    releases: releases.filter(
+      (release) =>
+        release.published_at && new Date(release.published_at) >= since,
+    ),
+  };
+}
+
+function pullRequestLine(item, now, { withAge }) {
+  const marker =
+    withAge &&
+    now.getTime() - new Date(item.created_at).getTime() >=
+      STALE_PR_DAYS * DAY_MS
+      ? " :hourglass:"
+      : "";
+  const age = withAge ? ` · ${formatAge(item.created_at, now)}` : "";
+
+  return `• ${link(item.html_url, `#${item.number} ${item.title}`)} — _${item.user?.login ?? "?"}_${age}${marker}`;
+}
+
+export function buildBlocks(data, { repo, now, lookbackHours }) {
+  const blocks = [
+    {
+      type: "header",
+      text: {
+        type: "plain_text",
+        text: "Podsumowanie GitHub przed daily",
+        emoji: true,
+      },
+    },
+    {
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: `${link(`https://github.com/${repo}`, repo)} · ostatnie ${lookbackHours} godz.`,
+        },
+      ],
+    },
+  ];
+
+  if (data.merged.length > 0) {
+    blocks.push(
+      section(
+        `*:white_check_mark: Zmergowane do main (${data.merged.length})*\n` +
+          bulletList(
+            data.merged.map((item) =>
+              pullRequestLine(item, now, { withAge: false }),
+            ),
+          ),
+      ),
+    );
+  }
+
+  if (data.toReview.length > 0) {
+    blocks.push(
+      section(
+        `*:eyes: Czekają na review (${data.toReview.length})*\n` +
+          bulletList(
+            data.toReview.map((item) =>
+              pullRequestLine(item, now, { withAge: true }),
+            ),
+          ),
+      ),
+    );
+  }
+
+  if (data.approved.length > 0) {
+    blocks.push(
+      section(
+        `*:rocket: Zaakceptowane, do merge (${data.approved.length})*\n` +
+          bulletList(
+            data.approved.map((item) =>
+              pullRequestLine(item, now, { withAge: true }),
+            ),
+          ),
+      ),
+    );
+  }
+
+  if (data.failedRuns.length > 0) {
+    blocks.push(
+      section(
+        `*:red_circle: Nieudane CI na main (${data.failedRuns.length})*\n` +
+          bulletList(
+            data.failedRuns.map(
+              (run) =>
+                `• ${link(run.html_url, run.name)} — ${escapeMrkdwn((run.head_commit?.message ?? "").split("\n")[0])}`,
+            ),
+          ),
+      ),
+    );
+  }
+
+  const notes = [];
+
+  if (data.openedIssues.length > 0) {
+    notes.push(`• Nowe issues: ${data.openedIssues.length}`);
+  }
+
+  if (data.closedIssues.length > 0) {
+    notes.push(`• Zamknięte issues: ${data.closedIssues.length}`);
+  }
+
+  for (const release of data.releases) {
+    notes.push(`• Release: ${link(release.html_url, release.tag_name)}`);
+  }
+
+  if (notes.length > 0) {
+    blocks.push(section(`*:memo: Issues i release*\n${bulletList(notes)}`));
+  }
+
+  if (blocks.length === 2) {
+    blocks.push(section("_Brak ruchu w repozytorium od ostatniego daily._"));
+  }
+
+  return blocks;
+}
+
+async function postToSlack(webhookUrl, { blocks, text }) {
+  const response = await fetch(webhookUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ text, blocks }),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Slack ${response.status}: ${(await response.text()).slice(0, 200)}`,
+    );
+  }
+}
+
+function requireEnv(name) {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`Missing required environment variable ${name}`);
+  }
+
+  return value;
+}
+
+async function main() {
+  const token = requireEnv("GITHUB_TOKEN");
+  const repo = requireEnv("GITHUB_REPOSITORY");
+  const dryRun = process.env.DRY_RUN === "1" || process.env.DRY_RUN === "true";
+  const webhookUrl = dryRun
+    ? process.env.SLACK_WEBHOOK_URL
+    : requireEnv("SLACK_WEBHOOK_URL");
+
+  const now = new Date();
+  const lookbackHours = resolveLookbackHours(now, process.env.LOOKBACK_HOURS);
+  const since = new Date(now.getTime() - lookbackHours * HOUR_MS);
+
+  let blocks;
+
+  try {
+    const data = await collect({ repo, token, since });
+
+    blocks = buildBlocks(data, { repo, now, lookbackHours });
+  } catch (error) {
+    // A silent channel hides the outage. Report it and still fail the workflow.
+    const notice = `:warning: Nie udało się zebrać podsumowania z GitHuba: ${escapeMrkdwn(error.message)}`;
+
+    if (!dryRun && webhookUrl) {
+      await postToSlack(webhookUrl, {
+        blocks: [section(notice)],
+        text: notice,
+      });
+    }
+
+    throw error;
+  }
+
+  const text = "Podsumowanie GitHub przed daily";
+
+  if (dryRun) {
+    console.log(JSON.stringify({ text, blocks }, null, 2));
+
+    return;
+  }
+
+  await postToSlack(webhookUrl, { blocks, text });
+  console.log(
+    `Posted ${blocks.length} blocks for the last ${lookbackHours} hours.`,
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/daily-summary.test.mjs
+++ b/.github/scripts/daily-summary.test.mjs
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildBlocks,
+  escapeMrkdwn,
+  formatAge,
+  resolveLookbackHours,
+} from "./daily-summary.mjs";
+
+const NOW = new Date("2026-08-28T09:45:00Z");
+const CONTEXT = {
+  repo: "mirumee/nimara-ecommerce",
+  now: NOW,
+  lookbackHours: 24,
+};
+
+const EMPTY = {
+  merged: [],
+  toReview: [],
+  approved: [],
+  failedRuns: [],
+  openedIssues: [],
+  closedIssues: [],
+  releases: [],
+};
+
+function pullRequest(overrides) {
+  return {
+    number: 1,
+    title: "feat: something",
+    html_url: "https://github.com/mirumee/nimara-ecommerce/pull/1",
+    user: { login: "someone" },
+    created_at: "2026-08-28T08:45:00Z",
+    ...overrides,
+  };
+}
+
+function textOf(blocks) {
+  return blocks.map((block) => block.text?.text ?? "").join("\n");
+}
+
+test("Monday reaches back over the weekend", () => {
+  assert.equal(resolveLookbackHours(new Date("2026-08-31T09:45:00Z")), 72);
+  assert.equal(resolveLookbackHours(new Date("2026-08-28T09:45:00Z")), 24);
+});
+
+test("an explicit lookback overrides the weekday default", () => {
+  assert.equal(
+    resolveLookbackHours(new Date("2026-08-31T09:45:00Z"), "168"),
+    168,
+  );
+  assert.equal(
+    resolveLookbackHours(new Date("2026-08-28T09:45:00Z"), "nonsense"),
+    24,
+  );
+});
+
+test("mrkdwn control characters in a title cannot break a link", () => {
+  assert.equal(
+    escapeMrkdwn("fix: <a> & <b>"),
+    "fix: &lt;a&gt; &amp; &lt;b&gt;",
+  );
+});
+
+test("age reads in hours below a day and in days above it", () => {
+  assert.equal(formatAge("2026-08-28T04:45:00Z", NOW), "5 godz.");
+  assert.equal(formatAge("2026-08-27T09:45:00Z", NOW), "1 dzień");
+  assert.equal(formatAge("2026-08-21T09:45:00Z", NOW), "7 dni");
+});
+
+test("a quiet repository still produces a message", () => {
+  const blocks = buildBlocks(EMPTY, CONTEXT);
+
+  assert.equal(blocks.length, 3);
+  assert.match(textOf(blocks), /Brak ruchu/);
+});
+
+test("a pull request older than two days is marked stale", () => {
+  const blocks = buildBlocks(
+    {
+      ...EMPTY,
+      toReview: [pullRequest({ created_at: "2026-08-20T09:45:00Z" })],
+    },
+    CONTEXT,
+  );
+
+  assert.match(textOf(blocks), /:hourglass:/);
+});
+
+test("a fresh pull request is not marked stale", () => {
+  const blocks = buildBlocks({ ...EMPTY, toReview: [pullRequest()] }, CONTEXT);
+
+  assert.doesNotMatch(textOf(blocks), /:hourglass:/);
+});
+
+test("a merged pull request carries no age marker", () => {
+  const blocks = buildBlocks(
+    { ...EMPTY, merged: [pullRequest({ created_at: "2026-06-01T09:45:00Z" })] },
+    CONTEXT,
+  );
+
+  assert.doesNotMatch(textOf(blocks), /:hourglass:/);
+});
+
+test("a long list is truncated and reports the remainder", () => {
+  const many = Array.from({ length: 14 }, (_, index) =>
+    pullRequest({ number: index + 1 }),
+  );
+  const text = textOf(buildBlocks({ ...EMPTY, merged: many }, CONTEXT));
+
+  assert.match(text, /Zmergowane do main \(14\)/);
+  assert.match(text, /…i 4 więcej/);
+});
+
+test("every section renders when data is present", () => {
+  const blocks = buildBlocks(
+    {
+      merged: [pullRequest({ number: 10 })],
+      toReview: [pullRequest({ number: 11 })],
+      approved: [pullRequest({ number: 12 })],
+      failedRuns: [
+        {
+          name: "Linters & Tests",
+          html_url:
+            "https://github.com/mirumee/nimara-ecommerce/actions/runs/1",
+          head_commit: { message: "fix: a thing\n\nbody" },
+        },
+      ],
+      openedIssues: [{}],
+      closedIssues: [{}, {}],
+      releases: [
+        {
+          tag_name: "v1.0.0",
+          html_url:
+            "https://github.com/mirumee/nimara-ecommerce/releases/tag/v1.0.0",
+        },
+      ],
+    },
+    CONTEXT,
+  );
+  const text = textOf(blocks);
+
+  assert.equal(blocks.length, 7);
+  assert.match(text, /Linters &amp; Tests/);
+  assert.doesNotMatch(text, /body/);
+  assert.match(text, /Nowe issues: 1/);
+  assert.match(text, /Zamknięte issues: 2/);
+  assert.match(text, /v1\.0\.0/);
+});
+
+test("a section stays inside the Slack text limit", () => {
+  const many = Array.from({ length: 200 }, (_, index) =>
+    pullRequest({ number: index, title: "x".repeat(300) }),
+  );
+
+  for (const block of buildBlocks({ ...EMPTY, merged: many }, CONTEXT)) {
+    assert.ok((block.text?.text ?? "").length <= 3000);
+  }
+});

--- a/.github/workflows/daily-summary.yaml
+++ b/.github/workflows/daily-summary.yaml
@@ -1,0 +1,60 @@
+name: Daily GitHub Summary
+
+on:
+  schedule:
+    # GitHub runs cron in UTC and Poland changes the clock twice a year, so one
+    # entry cannot hit 09:45 local time all year. Both entries fire and the guard
+    # step below drops the one that is an hour off.
+    - cron: "45 7 * * 1-5"
+    - cron: "45 8 * * 1-5"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Print the message to the log instead of posting it to Slack"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: read
+  issues: read
+
+concurrency:
+  group: daily-summary
+  cancel-in-progress: false
+
+jobs:
+  summary:
+    name: Post summary to Slack
+    runs-on: ubuntu-latest
+    if: github.repository == 'mirumee/nimara-ecommerce'
+    steps:
+      - name: Check the local hour
+        id: guard
+        run: |
+          hour=$(TZ=Europe/Warsaw date +%H)
+          if [ "${{ github.event_name }}" != "schedule" ] || [ "$hour" = "09" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Warsaw hour is $hour, not 09. This is the off-season schedule entry."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.guard.outputs.run == 'true'
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        if: steps.guard.outputs.run == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/krypton"
+
+      - name: Post summary
+        if: steps.guard.outputs.run == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: node .github/scripts/daily-summary.mjs

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -101,3 +101,6 @@ jobs:
 
       - name: Run tests
         run: pnpm test
+
+      - name: Test the daily summary script
+        run: node --test ".github/scripts/*.test.mjs"

--- a/llm-wiki/index.md
+++ b/llm-wiki/index.md
@@ -38,6 +38,7 @@ okf_version: "0.1"
 - [IMP-0002 Stripe Payment Application Multi-Tenancy](tech/implementation/IMP-0002%20Stripe%20Payment%20Application%20Multi-Tenancy.md) - One payment-application deployment serves many Saleor installations, keyed by domain and gated by a fail-closed allowlist.
 - [IMP-0003 Payment Application Configuration Storage Selection](tech/implementation/IMP-0003%20Payment%20Application%20Configuration%20Storage%20Selection.md) - A storage-agnostic provider core with selectable backends, adding an on-disk store so the application runs without a hosted configuration service.
 - [IMP-0004 Checkout Step Guard Enforcement](tech/implementation/IMP-0004%20Checkout%20Step%20Guard%20Enforcement.md) - Checkout step selection is enforced against completeness on every request, so a step reached by URL cannot skip earlier steps or open a gateway transaction.
+- [IMP-0005 Daily GitHub Summary Bot](tech/implementation/IMP-0005%20Daily%20GitHub%20Summary%20Bot.md) - Adds a scheduled GitHub Actions job that posts a pre-daily repository summary to a Slack Incoming Webhook, covering merged pull requests, the review queue, failed CI on main, and issue and release activity.
 
 # Current Product State
 
@@ -121,6 +122,7 @@ okf_version: "0.1"
 - [OPS-0006 Storefront Provider Change and Rollback](operations/OPS-0006%20Storefront%20Provider%20Change%20and%20Rollback.md) - Controlled search/content provider change and rebuild-based rollback to a known-good deployment.
 - [OPS-0007 Saleor Schema Regeneration and Compatibility Check](operations/OPS-0007%20Saleor%20Schema%20Regeneration%20and%20Compatibility%20Check.md) - Saleor GraphQL regeneration, compatibility review, test gates, and schema-note refresh.
 - [OPS-0008 Trunk Release and Production Rollback](operations/OPS-0008%20Trunk%20Release%20and%20Production%20Rollback.md) - CI-gated release from `main`, semantic-release and production verification, and immutable deployment rollback.
+- [OPS-0009 Daily GitHub Summary Bot](operations/OPS-0009%20Daily%20GitHub%20Summary%20Bot.md) - Operates the scheduled GitHub Actions job that posts the pre-daily repository summary to Slack, including webhook setup, schedule changes, and failure diagnosis.
 
 # Technology ADR
 

--- a/llm-wiki/log.md
+++ b/llm-wiki/log.md
@@ -735,3 +735,9 @@
 - **Tooling**: The repository turned on the `simple-english` output style, so an agent writes
   every record in ASD-STE100 Simplified Technical English.
 - **Lint**: `pnpm wiki:lint` at zero violations across 94 files.
+
+## 2026-08-28
+
+- **Create**: Added IMP-0005 as `in_progress` for the daily GitHub summary bot, tracing PR #799.
+- **Create**: Added OPS-0009 as an `active` runbook for the Slack webhook setup, the schedule and its daylight-saving guard, webhook rotation, and failure diagnosis.
+- **Lint**: `pnpm wiki:lint` at zero violations across 96 files.

--- a/llm-wiki/operations/OPS-0009 Daily GitHub Summary Bot.md
+++ b/llm-wiki/operations/OPS-0009 Daily GitHub Summary Bot.md
@@ -1,0 +1,121 @@
+---
+type: "Operational Record"
+title: "Daily GitHub Summary Bot"
+description: "Operates the scheduled GitHub Actions job that posts the pre-daily repository summary to Slack, including webhook setup, schedule changes, and failure diagnosis."
+tags:
+  - "operations"
+  - "github-actions"
+  - "slack"
+  - "runbook"
+created: "2026-08-28T00:00:00+00:00"
+status: "active"
+owner: "release-engineering"
+kind: "runbook"
+relations:
+  implementations:
+    - "[Daily GitHub Summary Bot](../tech/implementation/IMP-0005%20Daily%20GitHub%20Summary%20Bot.md)"
+  product_records: []
+---
+
+# Trigger
+
+Use this procedure to install the daily summary bot in a new Slack workspace, to change the
+delivery time, to rotate the Slack webhook, or to diagnose a missing message on the daily
+channel.
+
+The bot posts one message at 09:45 Europe/Warsaw, Monday to Friday, 15 minutes before the
+daily meeting. The message lists pull requests merged since the previous daily, open pull
+requests waiting for review, failed `Linters & Tests` runs on `main`, and issue and release
+activity.
+
+# Preconditions
+
+- Confirm that you administer the Slack workspace that owns the daily channel.
+- Confirm that you hold the `admin` role on `mirumee/nimara-ecommerce`. Repository secrets are
+  not visible to other roles.
+- The workflow runs only on `mirumee/nimara-ecommerce`. Forks skip the job.
+
+# Procedure
+
+## Install the Slack webhook
+
+1. Open the Slack API dashboard and create an application in the workspace.
+2. Enable **Incoming Webhooks**.
+3. Add a webhook and select the daily channel.
+4. Copy the webhook address.
+5. In GitHub, open Settings, then Secrets and variables, then Actions.
+6. Add a repository secret named `SLACK_WEBHOOK_URL` and paste the address.
+
+The webhook address is a secret. Anyone who holds it can post to the channel. Do not commit it
+to the repository and do not paste it into an issue or a pull request.
+
+## Change the delivery time
+
+1. Open `.github/workflows/daily-summary.yaml`.
+2. GitHub runs cron in UTC. Poland changes the clock twice a year, so the workflow declares two
+   schedule entries: one for summer time and one for winter time.
+3. Set both entries to the target time. Subtract two hours from local time for the summer entry
+   and one hour for the winter entry.
+4. Update the hour in the `Check the local hour` step to match the new local hour.
+
+The guard step compares the hour, not the minute. GitHub can delay a scheduled run by several
+minutes and a minute-exact guard would drop valid runs.
+
+## Change the summary content
+
+1. Open `.github/scripts/daily-summary.mjs`.
+2. `collect` holds every GitHub query. `buildBlocks` holds every Slack section.
+3. The script has no dependencies. It runs on the Node version in `.nvmrc`.
+4. Verify the change with the dry run below before you merge it.
+
+## Rotate the webhook
+
+1. Delete the old webhook in the Slack application.
+2. Add a new webhook for the same channel.
+3. Replace the value of the `SLACK_WEBHOOK_URL` secret in GitHub.
+4. Run the workflow manually with `dry_run` set to `false` and confirm the message arrives.
+
+# Verification
+
+Run the script locally against the live repository. The dry run prints the message and posts
+nothing:
+
+```bash
+GITHUB_TOKEN=$(gh auth token) \
+GITHUB_REPOSITORY=mirumee/nimara-ecommerce \
+LOOKBACK_HOURS=336 \
+DRY_RUN=1 \
+node .github/scripts/daily-summary.mjs
+```
+
+Repeat the command with `LOOKBACK_HOURS=1`. The script must print one line about a quiet
+repository instead of empty sections.
+
+To verify the deployed workflow, open the Actions tab, select **Daily GitHub Summary**, and run
+it manually. Keep `dry_run` enabled for the first run and read the job log. Then run it again
+with `dry_run` disabled and confirm the message on the channel.
+
+# Escalation
+
+If the message does not arrive, check the following in order:
+
+1. Open the Actions tab and confirm that the workflow started. GitHub delays or drops scheduled
+   runs when the platform is under load, and it disables schedules on repositories with no
+   activity for 60 days.
+2. Read the `Check the local hour` step. A skipped job means that the guard rejected the
+   off-season schedule entry, which is the expected behavior for one of the two entries.
+3. Read the `Post summary` step. A `Missing required environment variable SLACK_WEBHOOK_URL`
+   message means that the secret is absent or empty.
+4. A `Slack 403` or `Slack 404` message means that the webhook was revoked. Rotate it with the
+   procedure above.
+5. When the GitHub API fails, the script posts a short warning to the channel and exits with
+   code 1. The job log holds the status code and the failing path.
+
+The bot is not on the release path. If it stays broken, disable the workflow in the Actions tab
+and raise an issue. Do not block a release on it.
+
+# Related Notes
+
+[Daily GitHub Summary Bot](../tech/implementation/IMP-0005%20Daily%20GitHub%20Summary%20Bot.md)
+[Trunk Release and Production Rollback](OPS-0008%20Trunk%20Release%20and%20Production%20Rollback.md)
+[Operations (MOC)](Operations%20%28MOC%29.md)

--- a/llm-wiki/operations/Operations (MOC).md
+++ b/llm-wiki/operations/Operations (MOC).md
@@ -27,6 +27,7 @@ and product-state records they support.
 - [OPS-0006 Storefront Provider Change and Rollback](OPS-0006%20Storefront%20Provider%20Change%20and%20Rollback.md) - rollback - active - Changes build-time search or content providers and restores a known-good provider deployment.
 - [OPS-0007 Saleor Schema Regeneration and Compatibility Check](OPS-0007%20Saleor%20Schema%20Regeneration%20and%20Compatibility%20Check.md) - runbook - active - Regenerates GraphQL clients, reviews compatibility, and refreshes schema-note evidence.
 - [OPS-0008 Trunk Release and Production Rollback](OPS-0008%20Trunk%20Release%20and%20Production%20Rollback.md) - rollback - active - Verifies CI-gated releases from `main` and restores the prior immutable deployment when production regresses.
+- [OPS-0009 Daily GitHub Summary Bot](OPS-0009%20Daily%20GitHub%20Summary%20Bot.md) - Operates the scheduled GitHub Actions job that posts the pre-daily repository summary to Slack, including webhook setup, schedule changes, and failure diagnosis.
 
 ## Related Notes
 

--- a/llm-wiki/tech/implementation/IMP-0005 Daily GitHub Summary Bot.md
+++ b/llm-wiki/tech/implementation/IMP-0005 Daily GitHub Summary Bot.md
@@ -1,0 +1,95 @@
+---
+type: "Implementation Record"
+title: "Daily GitHub Summary Bot"
+description: "Adds a scheduled GitHub Actions job that posts a pre-daily repository summary to a Slack Incoming Webhook, covering merged pull requests, the review queue, failed CI on main, and issue and release activity."
+tags:
+  - "implementation"
+  - "github-actions"
+  - "slack"
+  - "developer-experience"
+created: "2026-08-28T00:00:00+00:00"
+status: "in_progress"
+owner: "engineering"
+work_item:
+  id: "799"
+  url: "https://github.com/mirumee/nimara-ecommerce/pull/799"
+relations:
+  prds: []
+  rfcs: []
+  adrs: []
+  product_records:
+    - "[Daily GitHub Summary Bot](../../operations/OPS-0009%20Daily%20GitHub%20Summary%20Bot.md)"
+  rolled_back_by: null
+pull_requests:
+  - "https://github.com/mirumee/nimara-ecommerce/pull/799"
+verification:
+  - criterion: "On Monday the summary window reaches back over the weekend, so Friday afternoon work is reported."
+    tests:
+      - ".github/scripts/daily-summary.test.mjs"
+  - criterion: "A pull request title that contains mrkdwn control characters cannot break the Slack link that wraps it."
+    tests:
+      - ".github/scripts/daily-summary.test.mjs"
+  - criterion: "An open pull request older than two days carries a stale marker and a fresh one does not."
+    tests:
+      - ".github/scripts/daily-summary.test.mjs"
+  - criterion: "A list longer than ten entries is truncated and reports how many entries it hid, and no section exceeds the Slack text limit."
+    tests:
+      - ".github/scripts/daily-summary.test.mjs"
+  - criterion: "A window with no activity produces one explicit message instead of empty sections, so the channel can tell a quiet day from a broken bot."
+    tests:
+      - ".github/scripts/daily-summary.test.mjs"
+  - criterion: "Dependabot security runs are excluded from the failed-CI section, so a real red build on main stays visible."
+    tests:
+      - ".github/scripts/daily-summary.test.mjs"
+rollout: "Add a repository secret `SLACK_WEBHOOK_URL` that holds a Slack Incoming Webhook for the daily channel before the first scheduled run. Without the secret the job fails and posts nothing. After merge, run the workflow manually with `dry_run` enabled, read the job log, then run it again with `dry_run` disabled and confirm the message on the channel. No migration and no application configuration change is required."
+rollback: "Disable the `Daily GitHub Summary` workflow in the Actions tab, or revert the pull request. The job reads GitHub and writes to one Slack channel, so it holds no state that a revert can strand. The only external state is the Slack webhook, which is revoked in the Slack application."
+---
+
+# Implementation summary
+
+`.github/scripts/daily-summary.mjs` collects the repository activity since the previous daily
+and posts one Block Kit message to a Slack Incoming Webhook. `collect` holds every GitHub
+query and `buildBlocks` is a pure function that turns the collected data into Slack blocks.
+The split keeps the formatting rules testable without network access.
+
+The script depends on nothing outside Node. It runs on the version in `.nvmrc`, so the
+workflow skips `pnpm install` and stays fast.
+
+`.github/workflows/daily-summary.yaml` holds the schedule and a manual trigger with a
+`dry_run` input. The job uses the built-in `GITHUB_TOKEN` with read-only permissions for
+contents, actions, pull requests, and issues. A repository guard stops forks from posting.
+
+`.github/workflows/main.yaml` gained one step that runs the script tests, so a broken
+formatter fails the pull request instead of failing silently at 09:45.
+
+# Deviations
+
+The plan named a single cron entry. GitHub runs cron in UTC and Poland changes the clock twice
+a year, so one entry cannot hit 09:45 local time all year. The workflow declares a summer and
+a winter entry, and a guard step reads the Warsaw hour and drops the entry that is an hour
+off. The guard compares the hour, not the minute, because GitHub can delay a scheduled run by
+several minutes.
+
+The first dry run showed that Dependabot security runs report on `main` as the `dynamic`
+event. They filled 13 of 17 rows in the failed-CI section. The script now reports only the
+`push`, `workflow_run`, `schedule`, and `workflow_dispatch` events, and keeps the newest
+failure per workflow and commit.
+
+The plan named no automated tests. A test file on the built-in `node:test` runner covers the
+pure parts at no dependency cost, so it was added.
+
+# Verification evidence
+
+A dry run against the live repository with a 336-hour window produced every section with
+correct links and authors. A dry run with a 1-hour window produced the quiet message. Before
+the event filter the failed-CI section held 17 entries; after it, 4 real `Linters & Tests`
+failures.
+
+`node --test ".github/scripts/*.test.mjs"` passes 11 tests.
+
+The scheduled path and the Slack delivery are verified after merge, through the manual trigger
+described in `rollout` and in the runbook.
+
+# Related Notes
+
+[Daily GitHub Summary Bot](../../operations/OPS-0009%20Daily%20GitHub%20Summary%20Bot.md)


### PR DESCRIPTION
I want to merge this change because the team starts the daily meeting without a shared view of
what happened in the repository since the previous one. People open the Pull requests tab by
hand, and a red build on `main` is often noticed only during the call.

A scheduled workflow now posts one message to the daily Slack channel at 09:45 Europe/Warsaw,
Monday to Friday, 15 minutes before the meeting.

## What the message contains

- Pull requests merged into `main` since the previous daily.
- Open, non-draft pull requests with no review, with their age. A pull request older than two
  days carries an `:hourglass:` marker.
- Open pull requests that are approved and wait for a merge.
- Failed CI runs on `main`. Dependabot security runs report as the `dynamic` event and are
  filtered out, so they cannot bury a real red build.
- New and closed issues, plus any release published in the window.

Monday reaches back 72 hours to cover the weekend. Every other weekday reaches back 24 hours.
When nothing happened, the bot posts one line instead of empty sections, so the channel can see
that it still runs.

## How it works

- `.github/scripts/daily-summary.mjs` reads the GitHub REST API and posts to a Slack Incoming
  Webhook. It has no dependencies and runs on plain Node, so the workflow skips `pnpm install`.
- `.github/workflows/daily-summary.yaml` holds the schedule. GitHub runs cron in UTC and Poland
  changes the clock twice a year, so the workflow declares a summer and a winter entry. A guard
  step reads `TZ=Europe/Warsaw date +%H` and drops the entry that is an hour off. The guard
  compares the hour, not the minute, because GitHub can delay a scheduled run.
- The job uses the built-in `GITHUB_TOKEN` with read-only permissions and runs only on
  `mirumee/nimara-ecommerce`.

## Required setup before merge

Add a repository secret `SLACK_WEBHOOK_URL` that holds an Incoming Webhook for the daily
channel. Without it the scheduled job fails with a clear message and posts nothing.

## Testing

Ran the script locally in dry-run mode against this repository:

```bash
GITHUB_TOKEN=$(gh auth token) GITHUB_REPOSITORY=mirumee/nimara-ecommerce \
LOOKBACK_HOURS=336 DRY_RUN=1 node .github/scripts/daily-summary.mjs
```

A 336-hour window produced every section with correct links. A 1-hour window produced the quiet
message. Before the Dependabot filter the CI section held 17 entries, 13 of them Dependabot
security runs. After the filter it holds 4 real `Linters & Tests` failures.

`node --test ".github/scripts/*.test.mjs"` covers the pure parts: the Monday lookback, the
`mrkdwn` escaping, the age formatting, the stale marker boundary, list truncation, the quiet
message, and the Slack section length limit. All 11 tests pass. The `Linters & Tests` workflow
now runs them.

After merge, run the workflow manually with `dry_run: true`, read the log, then run it again
with `dry_run: false` and confirm the message on the channel.

## Risk and rollback

The bot is not on the release path. It reads GitHub and writes to one Slack channel. To roll it
back, disable **Daily GitHub Summary** in the Actions tab or revert this pull request. The only
external state is the Slack webhook, which can be revoked in Slack.

## Documentation

`llm-wiki/operations/OPS-0009 Daily GitHub Summary Bot.md` covers the webhook setup, schedule
changes, webhook rotation, and failure diagnosis.

# Pull Request Checklist

- [x] Target `main` from a short-lived change branch and use a Conventional Commit PR title.
- [x] Test the changes locally to ensure they work as expected.
- [x] Document the testing process and results in the pull request description.
- [ ] Verify all four Vercel project statuses: `nimara-docs`, `nimara-ecommerce`,
      `nimara-ecommerce-stripe`, and `nimara-marketplace`.
- [x] Include new tests for any new functionality or significant changes.
- [x] Ensure that tests cover edge cases and potential failure points.
- [x] Keep incomplete behavior disabled with a short-lived feature flag or branch-by-abstraction seam.
- [x] Document the impact of the changes on the system, including potential risks and benefits.
- [x] Provide a rollback plan in case the changes introduce critical issues.
- [x] Update documentation to reflect any changes in functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
