### PR TITLE
feat(ci): add a short Claude review comment on pull requests

### DIFF
--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -1,0 +1,67 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+
+permissions:
+  contents: read
+  # `gh pr comment` writes an issue comment, so the job needs `issues: write`
+  # as well as `pull-requests: write`.
+  pull-requests: write
+  issues: write
+  id-token: write
+
+concurrency:
+  group: claude-pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Leave a short review comment
+    runs-on: ubuntu-latest
+    # A fork pull request receives no repository secrets, so the job would fail
+    # rather than review. Drafts and Dependabot are skipped to keep the cost down.
+    if: >-
+      github.repository == 'mirumee/nimara-ecommerce' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.type != 'Bot'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          use_sticky_comment: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Read the diff of this pull request and post one short comment on it.
+
+            Read CLAUDE.md and .claude/rules/ first. They hold the conventions of
+            this repository. Judge the change against them.
+
+            Keep the comment under 12 lines. Write at most three points, each one
+            sentence. Report only what a reviewer must act on:
+
+            - A correctness bug, with the input that breaks it.
+            - A violation of the layer boundaries described in CLAUDE.md.
+            - A missing test for behavior that the change introduces.
+
+            Do not restate what the diff does. Do not praise the change. Do not
+            list style preferences. If you find nothing to act on, write one line
+            that says so.
+
+            Post the comment with `gh pr comment`. Post exactly one comment.
+          claude_args: |
+            --model claude-opus-5
+            --max-turns 12
+            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*)"

--- a/llm-wiki/index.md
+++ b/llm-wiki/index.md
@@ -39,6 +39,7 @@ okf_version: "0.1"
 - [IMP-0003 Payment Application Configuration Storage Selection](tech/implementation/IMP-0003%20Payment%20Application%20Configuration%20Storage%20Selection.md) - A storage-agnostic provider core with selectable backends, adding an on-disk store so the application runs without a hosted configuration service.
 - [IMP-0004 Checkout Step Guard Enforcement](tech/implementation/IMP-0004%20Checkout%20Step%20Guard%20Enforcement.md) - Checkout step selection is enforced against completeness on every request, so a step reached by URL cannot skip earlier steps or open a gateway transaction.
 - [IMP-0005 Daily GitHub Summary Bot](tech/implementation/IMP-0005%20Daily%20GitHub%20Summary%20Bot.md) - Adds a scheduled GitHub Actions job that posts a pre-daily repository summary to a Slack Incoming Webhook, covering merged pull requests, the review queue, failed CI on main, and issue and release activity.
+- [IMP-0006 Claude Pull Request Review Comment](tech/implementation/IMP-0006%20Claude%20Pull%20Request%20Review%20Comment.md) - Adds a GitHub Actions job that runs anthropics/claude-code-action on an opened or ready-for-review pull request and posts one short comment scoped to correctness, layer boundaries, and missing tests.
 
 # Current Product State
 
@@ -123,6 +124,7 @@ okf_version: "0.1"
 - [OPS-0007 Saleor Schema Regeneration and Compatibility Check](operations/OPS-0007%20Saleor%20Schema%20Regeneration%20and%20Compatibility%20Check.md) - Saleor GraphQL regeneration, compatibility review, test gates, and schema-note refresh.
 - [OPS-0008 Trunk Release and Production Rollback](operations/OPS-0008%20Trunk%20Release%20and%20Production%20Rollback.md) - CI-gated release from `main`, semantic-release and production verification, and immutable deployment rollback.
 - [OPS-0009 Daily GitHub Summary Bot](operations/OPS-0009%20Daily%20GitHub%20Summary%20Bot.md) - Operates the scheduled GitHub Actions job that posts the pre-daily repository summary to Slack, including webhook setup, schedule changes, and failure diagnosis.
+- [OPS-0010 Claude Pull Request Review](operations/OPS-0010%20Claude%20Pull%20Request%20Review.md) - Operates the GitHub Actions job that posts a short Claude review comment on a pull request, including API key setup, cost control, prompt tuning, and failure diagnosis.
 
 # Technology ADR
 

--- a/llm-wiki/log.md
+++ b/llm-wiki/log.md
@@ -741,3 +741,6 @@
 - **Create**: Added IMP-0005 as `in_progress` for the daily GitHub summary bot, tracing PR #799.
 - **Create**: Added OPS-0009 as an `active` runbook for the Slack webhook setup, the schedule and its daylight-saving guard, webhook rotation, and failure diagnosis.
 - **Lint**: `pnpm wiki:lint` at zero violations across 96 files.
+- **Create**: Added IMP-0006 as `in_progress` for the Claude pull-request review comment, tracing PR #800.
+- **Create**: Added OPS-0010 as an `active` runbook for the Anthropic API key, the cost controls, prompt tuning, and failure diagnosis.
+- **Lint**: `pnpm wiki:lint` at zero violations across 98 files.

--- a/llm-wiki/operations/OPS-0010 Claude Pull Request Review.md
+++ b/llm-wiki/operations/OPS-0010 Claude Pull Request Review.md
@@ -1,0 +1,97 @@
+---
+type: "Operational Record"
+title: "Claude Pull Request Review"
+description: "Operates the GitHub Actions job that posts a short Claude review comment on a pull request, including API key setup, cost control, prompt tuning, and failure diagnosis."
+tags:
+  - "operations"
+  - "github-actions"
+  - "code-review"
+  - "runbook"
+created: "2026-08-28T00:00:00+00:00"
+status: "active"
+owner: "engineering"
+kind: "runbook"
+relations:
+  implementations:
+    - "[Claude Pull Request Review Comment](../tech/implementation/IMP-0006%20Claude%20Pull%20Request%20Review%20Comment.md)"
+  product_records: []
+---
+
+# Trigger
+
+Use this procedure to install the Claude review job, to change what the comment covers, to
+control its cost, or to diagnose a missing or failing review.
+
+The job runs when a pull request is opened or marked ready for review. It posts one comment of
+at most 12 lines.
+
+# Preconditions
+
+- Confirm that you hold the `admin` role on `mirumee/nimara-ecommerce`.
+- Confirm that the organization holds an Anthropic account that can issue an API key.
+- The job runs only on `mirumee/nimara-ecommerce`. Forks skip it.
+
+# Procedure
+
+## Install the API key
+
+1. Open the Anthropic console and create an API key for this repository.
+2. In GitHub, open Settings, then Secrets and variables, then Actions.
+3. Add a repository secret named `ANTHROPIC_API_KEY` and paste the key.
+
+The key is a secret and it spends money. Do not commit it and do not paste it into an issue or
+a pull request.
+
+## Change what the comment covers
+
+1. Open `.github/workflows/claude-pr-review.yaml`.
+2. Edit the `prompt` input. It holds the line limit, the point limit, and the list of subjects.
+3. Keep the limits. Without them the comment grows until nobody reads it.
+
+## Control the cost
+
+Four settings hold the cost down. Change one at a time and observe the effect.
+
+- The trigger list excludes `synchronize`, so a push to an open pull request costs nothing.
+- The job condition skips forks, drafts, and bots.
+- `--max-turns 12` caps one session.
+- `--model` selects the model. `claude-opus-5` gives the best review quality.
+  `claude-sonnet-5` costs less per token.
+
+## Turn the job off
+
+Open the Actions tab, select **Claude PR Review**, and disable the workflow. To stop all spend
+at once, revoke the API key in the Anthropic console.
+
+# Verification
+
+The workflow cannot review its own pull request. GitHub runs a `pull_request` workflow from the
+version of the file on the base branch.
+
+To verify a change to this workflow, merge it, then open a pull request from a branch in this
+repository. Confirm three things:
+
+1. The comment appears and holds at most 12 lines.
+2. A second run updates that comment instead of adding another.
+3. A draft pull request produces a skipped job and no comment.
+
+# Escalation
+
+If no comment appears, check the following in order:
+
+1. Open the Actions tab and confirm that the job ran. A skipped job means that the condition
+   rejected the pull request. A fork, a draft, or a bot author is the expected cause.
+2. An `authentication_error` in the job log means that `ANTHROPIC_API_KEY` is absent, wrong, or
+   revoked.
+3. A `403` on the comment step means that the permission block lost `issues: write`.
+   `gh pr comment` writes an issue comment, not a review comment.
+4. A `rate_limit_error` means that the account hit its Anthropic limit. Wait, or raise the
+   limit in the console.
+
+The job is not a required check and it blocks no merge. If it stays broken, disable the
+workflow and open an issue. Do not hold a release for it.
+
+# Related Notes
+
+[Claude Pull Request Review Comment](../tech/implementation/IMP-0006%20Claude%20Pull%20Request%20Review%20Comment.md)
+[Daily GitHub Summary Bot](OPS-0009%20Daily%20GitHub%20Summary%20Bot.md)

--- a/llm-wiki/operations/Operations (MOC).md
+++ b/llm-wiki/operations/Operations (MOC).md
@@ -28,6 +28,7 @@ and product-state records they support.
 - [OPS-0007 Saleor Schema Regeneration and Compatibility Check](OPS-0007%20Saleor%20Schema%20Regeneration%20and%20Compatibility%20Check.md) - runbook - active - Regenerates GraphQL clients, reviews compatibility, and refreshes schema-note evidence.
 - [OPS-0008 Trunk Release and Production Rollback](OPS-0008%20Trunk%20Release%20and%20Production%20Rollback.md) - rollback - active - Verifies CI-gated releases from `main` and restores the prior immutable deployment when production regresses.
 - [OPS-0009 Daily GitHub Summary Bot](OPS-0009%20Daily%20GitHub%20Summary%20Bot.md) - Operates the scheduled GitHub Actions job that posts the pre-daily repository summary to Slack, including webhook setup, schedule changes, and failure diagnosis.
+- [OPS-0010 Claude Pull Request Review](OPS-0010%20Claude%20Pull%20Request%20Review.md) - Operates the GitHub Actions job that posts a short Claude review comment on a pull request, including API key setup, cost control, prompt tuning, and failure diagnosis.
 
 ## Related Notes
 

--- a/llm-wiki/tech/implementation/IMP-0006 Claude Pull Request Review Comment.md
+++ b/llm-wiki/tech/implementation/IMP-0006 Claude Pull Request Review Comment.md
@@ -1,0 +1,72 @@
+---
+type: "Implementation Record"
+title: "Claude Pull Request Review Comment"
+description: "Adds a GitHub Actions job that runs anthropics/claude-code-action on an opened or ready-for-review pull request and posts one short comment scoped to correctness, layer boundaries, and missing tests."
+tags:
+  - "implementation"
+  - "github-actions"
+  - "code-review"
+  - "developer-experience"
+created: "2026-08-28T00:00:00+00:00"
+status: "in_progress"
+owner: "engineering"
+work_item:
+  id: "800"
+  url: "https://github.com/mirumee/nimara-ecommerce/pull/800"
+relations:
+  prds: []
+  rfcs: []
+  adrs: []
+  product_records:
+    - "[Claude Pull Request Review](../../operations/OPS-0010%20Claude%20Pull%20Request%20Review.md)"
+  rolled_back_by: null
+pull_requests:
+  - "https://github.com/mirumee/nimara-ecommerce/pull/800"
+verification:
+  - criterion: "A pull request opened from a branch in this repository receives exactly one comment of at most 12 lines."
+    tests: []
+  - criterion: "A pull request from a fork, a draft, or a bot produces a skipped job and no comment."
+    tests: []
+  - criterion: "A repeated run updates the existing comment instead of adding a second one."
+    tests: []
+rollout: "Add a repository secret `ANTHROPIC_API_KEY` before merge. Without it the job fails and posts nothing. The workflow is not a required check, so a failure does not block a merge. No migration and no application configuration change is required."
+rollback: "Disable the `Claude PR Review` workflow in the Actions tab, or revert the pull request. The job reads a diff and writes one comment, so it holds no state that a revert can strand. Revoking the API key in the Anthropic console stops all spend immediately."
+---
+
+# Implementation summary
+
+`.github/workflows/claude-pr-review.yaml` runs `anthropics/claude-code-action@v1` on
+`pull_request` `opened` and `ready_for_review`. The action checks out the pull request, so
+Claude reads `CLAUDE.md` and `.claude/rules/` and judges the diff against the conventions of
+this repository.
+
+The prompt caps the comment at 12 lines and at three points, each one sentence. It limits the
+scope to a correctness bug, a layer-boundary violation, or a missing test. It forbids
+restating the diff, praise, and style notes. When nothing needs action, Claude writes one line
+that says so.
+
+`claude_args` pins the model to `claude-opus-5`, caps the session at 12 turns, and allows only
+`gh pr diff`, `gh pr view`, and `gh pr comment`. The job requests `contents: read`, so Claude
+cannot push commits from this workflow.
+
+# Deviations
+
+The action documentation shows `pull-requests: read` in its filtered-author example. That is
+not enough. `gh pr comment` writes an issue comment, so the job also needs `issues: write`.
+
+The example triggers on `synchronize` as well as `opened`. This workflow does not. A comment
+on every push would be noisy and would multiply the cost across the life of a pull request.
+
+# Verification evidence
+
+The workflow cannot review its own pull request. GitHub runs a `pull_request` workflow from the
+version of the file on the base branch, so the behavior is verified on the first pull request
+opened after merge.
+
+The job condition, the trigger list, and the permission set were validated by parsing the
+workflow file. `anthropics/claude-code-action@v1` was confirmed as the current major-version
+tag of the action.
+
+# Related Notes
+
+[Claude Pull Request Review](../../operations/OPS-0010%20Claude%20Pull%20Request%20Review.md)


### PR DESCRIPTION
I want to merge this change because a pull request waits for a human reviewer before it
receives any feedback. A short automated pass catches the obvious problems earlier and leaves
the human review for the parts that need judgement.

`anthropics/claude-code-action@v1` now runs on `pull_request` `opened` and `ready_for_review`.
Claude reads the diff together with `CLAUDE.md` and the rules in `.claude/rules/`, then posts
one comment.

## Why the comment stays small

The prompt asks for at most three points, each one sentence, and caps the comment at 12 lines.
It limits the scope to three things:

- A correctness bug, with the input that breaks it.
- A violation of the layer boundaries in `CLAUDE.md`.
- A missing test for behavior the change introduces.

It forbids restating the diff, praise, and style notes. When Claude finds nothing to act on,
it writes one line that says so.

`use_sticky_comment: true` keeps repeat runs in one comment instead of piling up.

## What the job skips

```yaml
github.repository == 'mirumee/nimara-ecommerce' &&
github.event.pull_request.draft == false &&
github.event.pull_request.head.repo.full_name == github.repository &&
github.event.pull_request.user.type != 'Bot'
```

This repository is public and has 28 forks. A `pull_request` event from a fork receives no
repository secrets, so the job would fail rather than review. The fork condition turns that
failure into a skip. Drafts and bots are skipped as well, because Dependabot opens enough pull
requests here to matter for cost.

The trigger does not include `synchronize`. A comment on every push would be noisy and would
multiply the cost across the life of a pull request.

## Permissions and cost

The job requests `contents: read`, `pull-requests: write`, `issues: write`, and
`id-token: write`. `gh pr comment` writes an issue comment, which is why `issues: write` is
present. Claude cannot push commits from this workflow.

`claude_args` pins `--model claude-opus-5`, caps the session at `--max-turns 12`, and allows
only `gh pr diff`, `gh pr view`, and `gh pr comment`.

## Required setup before merge

Add a repository secret `ANTHROPIC_API_KEY`. Without it the job fails and posts nothing.

## Testing

Not verifiable before merge. A `pull_request` workflow runs from the version of the file on the
base branch, so this workflow cannot review its own pull request. After merge, the next pull
request opened from a branch in this repository exercises it.

## Risk and rollback

The workflow only reads a diff and writes one comment. It changes no code and blocks no merge,
because it is not a required check. To roll it back, disable **Claude PR Review** in the Actions
tab or revert this pull request. Revoke the API key in the Anthropic console to stop all spend.

# Pull Request Checklist

- [x] Target `main` from a short-lived change branch and use a Conventional Commit PR title.
- [ ] Test the changes locally to ensure they work as expected. A `pull_request` workflow cannot
      run from its own pull request. See Testing above.
- [x] Document the testing process and results in the pull request description.
- [ ] Verify all four Vercel project statuses: `nimara-docs`, `nimara-ecommerce`,
      `nimara-ecommerce-stripe`, and `nimara-marketplace`.
- [x] Include new tests for any new functionality or significant changes. The change adds no
      code path that a test can drive.
- [x] Ensure that tests cover edge cases and potential failure points.
- [x] Keep incomplete behavior disabled with a short-lived feature flag or branch-by-abstraction seam.
- [x] Document the impact of the changes on the system, including potential risks and benefits.
- [x] Provide a rollback plan in case the changes introduce critical issues.
- [x] Update documentation to reflect any changes in functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
