### PR TITLE
feat(ci): add a short Claude comment to the daily Slack summary

### DIFF
--- a/.github/scripts/daily-summary.mjs
+++ b/.github/scripts/daily-summary.mjs
@@ -12,6 +12,23 @@ const DEFAULT_LOOKBACK_HOURS = 24;
 const MONDAY_LOOKBACK_HOURS = 72;
 const SLACK_SECTION_LIMIT = 2900;
 
+const ANTHROPIC_API = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_VERSION = "2023-06-01";
+const ANTHROPIC_MODEL = "claude-opus-5";
+/**
+ * Adaptive thinking is on by default and its tokens count against max_tokens,
+ * so a two-sentence answer still needs headroom.
+ */
+const ANTHROPIC_MAX_TOKENS = 4000;
+const COMMENT_SYSTEM_PROMPT = [
+  "Jesteś częścią bota, który wysyła zespołowi podsumowanie GitHuba przed daily.",
+  "Dostajesz dane w JSON i piszesz jedno lub dwa zdania po polsku.",
+  "Napisz, na co zespół ma zwrócić uwagę na dzisiejszym daily.",
+  "Nie powtarzaj liczb, które i tak są w sekcjach poniżej.",
+  "Nie witaj się, nie podsumowuj danych, nie używaj emoji ani list.",
+  "Gdy nic nie wymaga uwagi, napisz jedno zdanie, że dzień jest spokojny.",
+].join(" ");
+
 /**
  * Dependabot security runs report as `dynamic`. They are not the team's CI and
  * would bury a real red build on main.
@@ -178,8 +195,8 @@ function pullRequestLine(item, now, { withAge }) {
   return `• ${link(item.html_url, `#${item.number} ${item.title}`)} — _${item.user?.login ?? "?"}_${age}${marker}`;
 }
 
-export function buildBlocks(data, { repo, now, lookbackHours }) {
-  const blocks = [
+export function buildBlocks(data, { repo, now, lookbackHours, comment }) {
+  const heading = [
     {
       type: "header",
       text: {
@@ -198,6 +215,8 @@ export function buildBlocks(data, { repo, now, lookbackHours }) {
       ],
     },
   ];
+
+  const blocks = [];
 
   if (data.merged.length > 0) {
     blocks.push(
@@ -270,11 +289,86 @@ export function buildBlocks(data, { repo, now, lookbackHours }) {
     blocks.push(section(`*:memo: Issues i release*\n${bulletList(notes)}`));
   }
 
-  if (blocks.length === 2) {
+  if (blocks.length === 0) {
     blocks.push(section("_Brak ruchu w repozytorium od ostatniego daily._"));
   }
 
-  return blocks;
+  if (comment) {
+    heading.push(section(`_${escapeMrkdwn(comment)}_`));
+  }
+
+  return [...heading, ...blocks];
+}
+
+/**
+ * Strips the collected data down to what the comment needs. Sending whole API
+ * payloads would cost tokens and add nothing.
+ */
+export function summarizeForPrompt(data) {
+  const titles = (items) => items.slice(0, 10).map((item) => item.title);
+
+  return {
+    zmergowane: titles(data.merged),
+    doReview: data.toReview.slice(0, 10).map((item) => ({
+      tytul: item.title,
+      utworzony: item.created_at,
+    })),
+    zaakceptowane: titles(data.approved),
+    nieudaneCi: data.failedRuns.slice(0, 10).map((run) => run.name),
+    noweIssues: data.openedIssues.length,
+    zamknieteIssues: data.closedIssues.length,
+    release: data.releases.map((release) => release.tag_name),
+  };
+}
+
+/**
+ * The comment is a nice-to-have. Any failure returns null so the summary still
+ * reaches the channel.
+ */
+async function requestComment(apiKey, data) {
+  try {
+    const response = await fetch(ANTHROPIC_API, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": apiKey,
+        "anthropic-version": ANTHROPIC_VERSION,
+      },
+      body: JSON.stringify({
+        model: ANTHROPIC_MODEL,
+        max_tokens: ANTHROPIC_MAX_TOKENS,
+        output_config: { effort: "low" },
+        system: COMMENT_SYSTEM_PROMPT,
+        messages: [
+          {
+            role: "user",
+            content: JSON.stringify(summarizeForPrompt(data)),
+          },
+        ],
+      }),
+    });
+
+    if (!response.ok) {
+      console.warn(
+        `Claude ${response.status}: ${(await response.text()).slice(0, 200)}`,
+      );
+
+      return null;
+    }
+
+    const body = await response.json();
+    const text = (body.content ?? [])
+      .filter((block) => block.type === "text")
+      .map((block) => block.text)
+      .join(" ")
+      .trim();
+
+    return text || null;
+  } catch (error) {
+    console.warn(`Claude comment skipped: ${error.message}`);
+
+    return null;
+  }
 }
 
 async function postToSlack(webhookUrl, { blocks, text }) {
@@ -317,8 +411,10 @@ async function main() {
 
   try {
     const data = await collect({ repo, token, since });
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    const comment = apiKey ? await requestComment(apiKey, data) : null;
 
-    blocks = buildBlocks(data, { repo, now, lookbackHours });
+    blocks = buildBlocks(data, { repo, now, lookbackHours, comment });
   } catch (error) {
     // A silent channel hides the outage. Report it and still fail the workflow.
     const notice = `:warning: Nie udało się zebrać podsumowania z GitHuba: ${escapeMrkdwn(error.message)}`;

--- a/.github/scripts/daily-summary.mjs
+++ b/.github/scripts/daily-summary.mjs
@@ -308,16 +308,16 @@ export function summarizeForPrompt(data) {
   const titles = (items) => items.slice(0, 10).map((item) => item.title);
 
   return {
-    zmergowane: titles(data.merged),
-    doReview: data.toReview.slice(0, 10).map((item) => ({
-      tytul: item.title,
-      utworzony: item.created_at,
+    merged: titles(data.merged),
+    awaitingReview: data.toReview.slice(0, 10).map((item) => ({
+      title: item.title,
+      createdAt: item.created_at,
     })),
-    zaakceptowane: titles(data.approved),
-    nieudaneCi: data.failedRuns.slice(0, 10).map((run) => run.name),
-    noweIssues: data.openedIssues.length,
-    zamknieteIssues: data.closedIssues.length,
-    release: data.releases.map((release) => release.tag_name),
+    approved: titles(data.approved),
+    failedCi: data.failedRuns.slice(0, 10).map((run) => run.name),
+    openedIssues: data.openedIssues.length,
+    closedIssues: data.closedIssues.length,
+    releases: data.releases.map((release) => release.tag_name),
   };
 }
 

--- a/.github/scripts/daily-summary.test.mjs
+++ b/.github/scripts/daily-summary.test.mjs
@@ -205,12 +205,12 @@ test("the prompt payload carries titles and counts, not whole API objects", () =
     releases: [{ tag_name: "v1.2.3" }],
   });
 
-  assert.deepEqual(payload.zmergowane, ["feat: a"]);
-  assert.deepEqual(payload.doReview, [
-    { tytul: "fix: b", utworzony: "2026-08-01T00:00:00Z" },
+  assert.deepEqual(payload.merged, ["feat: a"]);
+  assert.deepEqual(payload.awaitingReview, [
+    { title: "fix: b", createdAt: "2026-08-01T00:00:00Z" },
   ]);
-  assert.equal(payload.noweIssues, 2);
-  assert.deepEqual(payload.release, ["v1.2.3"]);
+  assert.equal(payload.openedIssues, 2);
+  assert.deepEqual(payload.releases, ["v1.2.3"]);
 });
 
 test("the prompt payload caps each list at ten entries", () => {
@@ -223,6 +223,6 @@ test("the prompt payload caps each list at ten entries", () => {
     toReview: many,
   });
 
-  assert.equal(payload.zmergowane.length, 10);
-  assert.equal(payload.doReview.length, 10);
+  assert.equal(payload.merged.length, 10);
+  assert.equal(payload.awaitingReview.length, 10);
 });

--- a/.github/scripts/daily-summary.test.mjs
+++ b/.github/scripts/daily-summary.test.mjs
@@ -6,6 +6,7 @@ import {
   escapeMrkdwn,
   formatAge,
   resolveLookbackHours,
+  summarizeForPrompt,
 } from "./daily-summary.mjs";
 
 const NOW = new Date("2026-08-28T09:45:00Z");
@@ -157,4 +158,71 @@ test("a section stays inside the Slack text limit", () => {
   for (const block of buildBlocks({ ...EMPTY, merged: many }, CONTEXT)) {
     assert.ok((block.text?.text ?? "").length <= 3000);
   }
+});
+
+test("a Claude comment sits above the sections", () => {
+  const blocks = buildBlocks(
+    { ...EMPTY, merged: [pullRequest()] },
+    {
+      ...CONTEXT,
+      comment: "Dwa PR-y czekają na review dłużej niż dwa tygodnie.",
+    },
+  );
+
+  assert.match(blocks[2].text.text, /Dwa PR-y czekają/);
+  assert.match(blocks[3].text.text, /Zmergowane do main/);
+});
+
+test("a comment does not suppress the quiet message", () => {
+  const blocks = buildBlocks(EMPTY, { ...CONTEXT, comment: "Spokojny dzień." });
+  const text = textOf(blocks);
+
+  assert.match(text, /Spokojny dzień/);
+  assert.match(text, /Brak ruchu/);
+});
+
+test("no comment leaves the block layout unchanged", () => {
+  assert.equal(buildBlocks(EMPTY, CONTEXT).length, 3);
+});
+
+test("a comment with mrkdwn control characters cannot break the message", () => {
+  const blocks = buildBlocks(EMPTY, {
+    ...CONTEXT,
+    comment: "Uwaga na <b> & spółkę",
+  });
+
+  assert.match(textOf(blocks), /Uwaga na &lt;b&gt; &amp; spółkę/);
+});
+
+test("the prompt payload carries titles and counts, not whole API objects", () => {
+  const payload = summarizeForPrompt({
+    ...EMPTY,
+    merged: [pullRequest({ title: "feat: a" })],
+    toReview: [
+      pullRequest({ title: "fix: b", created_at: "2026-08-01T00:00:00Z" }),
+    ],
+    openedIssues: [{}, {}],
+    releases: [{ tag_name: "v1.2.3" }],
+  });
+
+  assert.deepEqual(payload.zmergowane, ["feat: a"]);
+  assert.deepEqual(payload.doReview, [
+    { tytul: "fix: b", utworzony: "2026-08-01T00:00:00Z" },
+  ]);
+  assert.equal(payload.noweIssues, 2);
+  assert.deepEqual(payload.release, ["v1.2.3"]);
+});
+
+test("the prompt payload caps each list at ten entries", () => {
+  const many = Array.from({ length: 40 }, (_, index) =>
+    pullRequest({ number: index }),
+  );
+  const payload = summarizeForPrompt({
+    ...EMPTY,
+    merged: many,
+    toReview: many,
+  });
+
+  assert.equal(payload.zmergowane.length, 10);
+  assert.equal(payload.doReview.length, 10);
 });

--- a/.github/workflows/daily-summary.yaml
+++ b/.github/workflows/daily-summary.yaml
@@ -56,5 +56,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          # Optional. Without it the summary posts without the Claude comment.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: node .github/scripts/daily-summary.mjs

--- a/llm-wiki/index.md
+++ b/llm-wiki/index.md
@@ -39,6 +39,7 @@ okf_version: "0.1"
 - [IMP-0003 Payment Application Configuration Storage Selection](tech/implementation/IMP-0003%20Payment%20Application%20Configuration%20Storage%20Selection.md) - A storage-agnostic provider core with selectable backends, adding an on-disk store so the application runs without a hosted configuration service.
 - [IMP-0004 Checkout Step Guard Enforcement](tech/implementation/IMP-0004%20Checkout%20Step%20Guard%20Enforcement.md) - Checkout step selection is enforced against completeness on every request, so a step reached by URL cannot skip earlier steps or open a gateway transaction.
 - [IMP-0005 Daily GitHub Summary Bot](tech/implementation/IMP-0005%20Daily%20GitHub%20Summary%20Bot.md) - Adds a scheduled GitHub Actions job that posts a pre-daily repository summary to a Slack Incoming Webhook, covering merged pull requests, the review queue, failed CI on main, and issue and release activity.
+- [IMP-0006 Daily Summary Claude Comment](tech/implementation/IMP-0006%20Daily%20Summary%20Claude%20Comment.md) - Adds an optional Claude-written comment above the sections of the daily GitHub summary posted to Slack, trimmed to titles and counts before the request and degraded to no comment on any failure.
 
 # Current Product State
 

--- a/llm-wiki/log.md
+++ b/llm-wiki/log.md
@@ -741,3 +741,6 @@
 - **Create**: Added IMP-0005 as `in_progress` for the daily GitHub summary bot, tracing PR #799.
 - **Create**: Added OPS-0009 as an `active` runbook for the Slack webhook setup, the schedule and its daylight-saving guard, webhook rotation, and failure diagnosis.
 - **Lint**: `pnpm wiki:lint` at zero violations across 96 files.
+- **Create**: Added IMP-0006 as `in_progress` for the Claude comment on the daily summary, tracing PR #801.
+- **Maintenance**: Extended OPS-0009 with the Anthropic API key setup, the cost note, and the diagnosis for a missing comment.
+- **Lint**: `pnpm wiki:lint` at zero violations across 97 files.

--- a/llm-wiki/operations/OPS-0009 Daily GitHub Summary Bot.md
+++ b/llm-wiki/operations/OPS-0009 Daily GitHub Summary Bot.md
@@ -14,6 +14,7 @@ kind: "runbook"
 relations:
   implementations:
     - "[Daily GitHub Summary Bot](../tech/implementation/IMP-0005%20Daily%20GitHub%20Summary%20Bot.md)"
+    - "[Daily Summary Claude Comment](../tech/implementation/IMP-0006%20Daily%20Summary%20Claude%20Comment.md)"
   product_records: []
 ---
 
@@ -61,10 +62,24 @@ to the repository and do not paste it into an issue or a pull request.
 The guard step compares the hour, not the minute. GitHub can delay a scheduled run by several
 minutes and a minute-exact guard would drop valid runs.
 
+## Install the Claude API key
+
+The comment above the sections is optional. Without the key the bot posts the sections alone.
+
+1. Open the Anthropic console and create an API key.
+2. In GitHub, open Settings, then Secrets and variables, then Actions.
+3. Add a repository secret named `ANTHROPIC_API_KEY` and paste the key.
+
+The bot sends one request per weekday. It uses the model `claude-opus-5` at effort `low`, and
+it trims the data to titles and counts before the request, so one run costs a fraction of a
+cent. To drop the comment and keep the sections, delete the secret. No code change is needed.
+
 ## Change the summary content
 
 1. Open `.github/scripts/daily-summary.mjs`.
 2. `collect` holds every GitHub query. `buildBlocks` holds every Slack section.
+   `COMMENT_SYSTEM_PROMPT` holds the instructions for the Claude comment, and
+   `summarizeForPrompt` holds what Claude receives.
 3. The script has no dependencies. It runs on the Node version in `.nvmrc`.
 4. Verify the change with the dry run below before you merge it.
 
@@ -110,6 +125,16 @@ If the message does not arrive, check the following in order:
    procedure above.
 5. When the GitHub API fails, the script posts a short warning to the channel and exits with
    code 1. The job log holds the status code and the failing path.
+
+If the message arrives without the comment above the sections, the sections are correct and
+only the Claude call failed. Read the `Post summary` step for a `Claude` warning line:
+
+- No warning line means that `ANTHROPIC_API_KEY` is absent. The bot skipped the call.
+- `Claude 401` means that the key is wrong or revoked.
+- `Claude 429` means that the account hit its Anthropic rate limit.
+
+A failed comment never blocks the summary, so the job still succeeds. This is intended. The
+sections are the product and the comment is a garnish.
 
 The bot is not on the release path. If it stays broken, disable the workflow in the Actions tab
 and raise an issue. Do not block a release on it.

--- a/llm-wiki/tech/implementation/IMP-0006 Daily Summary Claude Comment.md
+++ b/llm-wiki/tech/implementation/IMP-0006 Daily Summary Claude Comment.md
@@ -1,0 +1,85 @@
+---
+type: "Implementation Record"
+title: "Daily Summary Claude Comment"
+description: "Adds an optional Claude-written comment above the sections of the daily GitHub summary posted to Slack, trimmed to titles and counts before the request and degraded to no comment on any failure."
+tags:
+  - "implementation"
+  - "github-actions"
+  - "slack"
+  - "claude-api"
+created: "2026-08-28T00:00:00+00:00"
+status: "in_progress"
+owner: "engineering"
+work_item:
+  id: "801"
+  url: "https://github.com/mirumee/nimara-ecommerce/pull/801"
+relations:
+  prds: []
+  rfcs: []
+  adrs: []
+  product_records:
+    - "[Daily GitHub Summary Bot](../../operations/OPS-0009%20Daily%20GitHub%20Summary%20Bot.md)"
+  rolled_back_by: null
+pull_requests:
+  - "https://github.com/mirumee/nimara-ecommerce/pull/801"
+verification:
+  - criterion: "The comment sits above the sections and does not replace the quiet-day message."
+    tests:
+      - ".github/scripts/daily-summary.test.mjs"
+  - criterion: "Without ANTHROPIC_API_KEY the block layout is unchanged and the summary still posts."
+    tests:
+      - ".github/scripts/daily-summary.test.mjs"
+  - criterion: "A failed Claude request logs a warning and the summary still reaches the channel."
+    tests: []
+  - criterion: "Control characters inside the comment cannot break the Slack message."
+    tests:
+      - ".github/scripts/daily-summary.test.mjs"
+  - criterion: "The prompt payload carries titles and counts only, capped at ten entries per list."
+    tests:
+      - ".github/scripts/daily-summary.test.mjs"
+rollout: "Add a repository secret `ANTHROPIC_API_KEY` to enable the comment. The secret is optional: without it the summary posts unchanged. After merge, run the workflow manually with `dry_run` enabled and read the comment in the job log, then run it again with `dry_run` disabled. No migration and no application configuration change is required."
+rollback: "Delete the `ANTHROPIC_API_KEY` secret to drop the comment and keep the summary. No code change and no deployment is needed. To remove the feature entirely, revert the pull request. Revoking the API key in the Anthropic console stops all spend."
+---
+
+# Implementation summary
+
+`requestComment` sends the collected activity to the Claude API and returns one or two
+sentences. `buildBlocks` places that text above the sections, in italics.
+
+`summarizeForPrompt` is a pure function that trims the data before the request: pull request
+titles, the age of the review queue, failed workflow names, issue counts, and release tags,
+each list capped at ten entries. Whole GitHub API payloads would cost tokens and add nothing.
+
+The comment is optional in both directions. Without `ANTHROPIC_API_KEY` the script skips the
+call. When the call fails, `requestComment` logs a warning and returns `null`. The summary is
+the product and the comment is a garnish, so a failure must never cost the channel its message.
+
+The request uses `claude-opus-5` at `effort: low`, which suits a two-sentence answer.
+
+# Deviations
+
+The work started as a review comment on pull requests, against `anthropics/claude-code-action`.
+That misread the request. The comment belongs to the Slack summary, not to a pull request. The
+review workflow was closed unmerged as PR #800 and never reached `main`.
+
+The request uses plain `fetch` rather than `@anthropic-ai/sdk`. The script has no dependencies
+and the workflow skips `pnpm install`, so an SDK would change how the job runs for one call.
+
+`max_tokens` is 4000 rather than a value matched to two sentences. Adaptive thinking is on by
+default on this model and its tokens count against the limit, so a small ceiling would truncate
+the answer.
+
+# Verification evidence
+
+`node --test ".github/scripts/*.test.mjs"` passes 17 tests, 6 of them added by this change.
+
+Both degraded paths were exercised against the live API endpoint with a dry run. With no key
+the message held 6 blocks and no comment block. With an invalid key the script logged
+`Claude 401` and still built the message.
+
+The successful call needs a real key, so it is verified after merge through the manual trigger
+described in `rollout`.
+
+# Related Notes
+
+[Daily GitHub Summary Bot](../../operations/OPS-0009%20Daily%20GitHub%20Summary%20Bot.md)


### PR DESCRIPTION
I want to merge this change because the daily Slack summary lists what happened but does not
say what matters. The reader still has to scan three sections and decide. One or two sentences
at the top do that work.

Claude now receives the collected activity and writes a short comment. The comment sits above
the sections, in italics.

## What Claude receives

`summarizeForPrompt` trims the data before it leaves the runner: pull request titles, the age
of the review queue, failed workflow names, issue counts, and release tags. Each list is capped
at ten entries. Whole GitHub API payloads would cost tokens and add nothing.

The system prompt asks for one or two sentences in Polish about what the team must notice. It
forbids repeating the numbers that the sections already carry, and forbids greetings, emoji,
and lists. On a quiet day it asks for one sentence saying so.

## The comment never breaks the summary

It is optional in both directions:

- Without `ANTHROPIC_API_KEY` the script skips the call and posts the summary unchanged.
- When the call fails, `requestComment` logs a warning and returns `null`. The summary still
  reaches the channel.

This matters because the summary is the product and the comment is a garnish. A channel with no
message at 09:45 is worse than a message with no comment.

## Cost

One request per weekday. The model is `claude-opus-5` at `effort: low`, which suits a
two-sentence answer. The trimmed payload is a few hundred tokens.

`max_tokens` is 4000 rather than something tiny. Adaptive thinking is on by default on this
model and its tokens count against the limit, so a small ceiling would truncate the answer.

## Testing

`node --test ".github/scripts/*.test.mjs"` passes 17 tests, 6 of them new: comment placement
above the sections, the comment not suppressing the quiet message, an unchanged layout without
a comment, `mrkdwn` escaping inside the comment, and the shape and the ten-entry cap of the
prompt payload.

Both degraded paths were exercised against the live API endpoint with a dry run:

```
# No key: 6 blocks, no comment block, message intact.
GITHUB_TOKEN=$(gh auth token) GITHUB_REPOSITORY=mirumee/nimara-ecommerce \
LOOKBACK_HOURS=168 DRY_RUN=1 node .github/scripts/daily-summary.mjs

# Invalid key: warns `Claude 401: ... API key is invalid.` and still builds the message.
ANTHROPIC_API_KEY=sk-ant-invalid-key-for-testing GITHUB_TOKEN=$(gh auth token) ... 
```

The successful call is the one path that needs a real key, so it is verified after merge. Run
the workflow manually with `dry_run: true` and read the comment in the job log, then run it
again with `dry_run: false`.

## Risk and rollback

To drop the comment and keep the summary, delete the `ANTHROPIC_API_KEY` secret. No code change
and no deployment is needed. To roll the change back entirely, revert this pull request.

## Documentation

`llm-wiki/operations/OPS-0009 Daily GitHub Summary Bot.md` gains the API key setup, the cost
note, and the diagnosis for a missing comment.

# Pull Request Checklist

- [x] Target `main` from a short-lived change branch and use a Conventional Commit PR title.
- [x] Test the changes locally to ensure they work as expected.
- [x] Document the testing process and results in the pull request description.
- [ ] Verify all four Vercel project statuses: `nimara-docs`, `nimara-ecommerce`,
      `nimara-ecommerce-stripe`, and `nimara-marketplace`.
- [x] Include new tests for any new functionality or significant changes.
- [x] Ensure that tests cover edge cases and potential failure points.
- [x] Keep incomplete behavior disabled with a short-lived feature flag or branch-by-abstraction seam.
      The comment is gated on the presence of `ANTHROPIC_API_KEY`.
- [x] Document the impact of the changes on the system, including potential risks and benefits.
- [x] Provide a rollback plan in case the changes introduce critical issues.
- [x] Update documentation to reflect any changes in functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
