### PR TITLE
chore(rules): forbid code comments in the agent rules

### DIFF
--- a/.claude/rules/comments.md
+++ b/.claude/rules/comments.md
@@ -1,11 +1,8 @@
 # Comments
 
-- Comment a decision the code cannot show, not what the code says. A name, type, or
-  signature that already carries the meaning needs no comment.
-- Keep it to one or two lines. Provider API background belongs in the vendor's docs, not
-  in a source file.
-- Never annotate a constant merely because it exists.
-- Never restate an architecture rule the code already follows. A derived type that names
-  no provider does not need a comment saying it names no provider.
-- Prefer a comment that would stop someone "fixing" correct code back to broken.
-- Use the expanded block form when a comment is warranted, never `/** one liner */`.
+- Do not write comments in code. This applies to new code and to code that you edit.
+- If a fragment needs an explanation, rename the symbol or extract a function.
+- Keep comments that already exist in the file. Do not delete them and do not extend them.
+- Exceptions: a license header, a pragma that the toolchain reads
+  (`@ts-expect-error`, `eslint-disable`, `biome-ignore`), and a JSDoc block that the
+  public API of a package must publish.


### PR DESCRIPTION
I want to merge this change because the agent rule about comments allowed comments in
several cases. The new rule forbids them, so generated code stays free of narration.

# What changed

- `.claude/rules/comments.md` now states that no comment is written in code.
- If a fragment needs an explanation, the agent must rename the symbol or extract a function.
- Comments that already exist in a file stay untouched.
- Narrow exceptions remain: a license header, a toolchain pragma
  (`@ts-expect-error`, `eslint-disable`, `biome-ignore`), and published JSDoc.

# Scope and risk

The change touches one Markdown file under `.claude/`. No application code, no
configuration, and no build input changed. The file is an instruction for coding agents,
so it changes how future code looks, not how the product runs.

Rollback plan: revert this commit. The previous rule text returns and nothing else moves.

# Testing

| Check | Result |
| --- | --- |
| `pnpm exec turbo run lint:staged` | 6 successful, 6 total |
| `pnpm format:check` | All matched files use Prettier code style |
| `pnpm test` | 6 successful, 6 total (265 tests passed) |

No screen recording applies. The change has no runtime surface.

# Pull Request Checklist

- [x] Target `main` from a short-lived change branch and use a Conventional Commit PR title.
- [x] Test the changes locally to ensure they work as expected.
- [x] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [ ] Verify all four Vercel project statuses: `nimara-docs`, `nimara-ecommerce`,
      `nimara-ecommerce-stripe`, and `nimara-marketplace`.
- [x] Include new tests for any new functionality or significant changes. — not applicable, the change is an agent instruction.
- [x] Ensure that tests cover edge cases and potential failure points. — not applicable.
- [x] Keep incomplete behavior disabled with a short-lived feature flag or branch-by-abstraction seam. — not applicable, the change is complete.
- [x] Document the impact of the changes on the system, including potential risks and benefits.
- [x] Provide a rollback plan in case the changes introduce critical issues.
- [x] Update documentation to reflect any changes in functionality. — the rule file is the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)