### PR TITLE
fix(ci): authenticate the Claude comment with either credential type

### DIFF
--- a/.github/scripts/daily-summary.mjs
+++ b/.github/scripts/daily-summary.mjs
@@ -8,8 +8,9 @@
 const GITHUB_API = "https://api.github.com";
 const MAX_LIST_ITEMS = 10;
 const STALE_PR_DAYS = 2;
-const DEFAULT_LOOKBACK_HOURS = 24;
-const MONDAY_LOOKBACK_HOURS = 72;
+const DAILY_LOOKBACK_HOURS = 24;
+const WEEKLY_LOOKBACK_HOURS = 168;
+const DESCRIPTION_LIMIT = 600;
 const SLACK_SECTION_LIMIT = 2900;
 
 const ANTHROPIC_API = "https://api.anthropic.com/v1/messages";
@@ -25,6 +26,8 @@ const ANTHROPIC_MAX_TOKENS = 4000;
 const COMMENT_SYSTEM_PROMPT = [
   "Jesteś częścią bota, który wysyła zespołowi podsumowanie GitHuba przed daily.",
   "Dostajesz dane w JSON i piszesz jedno lub dwa zdania po polsku.",
+  "Pole window mówi, czy podsumowujesz jeden dzień, czy cały zeszły tydzień.",
+  "Pole description to opis PR-a napisany przez autora. Bywa puste.",
   "Napisz, na co zespół ma zwrócić uwagę na dzisiejszym daily.",
   "Nie powtarzaj liczb, które i tak są w sekcjach poniżej.",
   "Nie witaj się, nie podsumowuj danych, nie używaj emoji ani list.",
@@ -46,17 +49,22 @@ const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * HOUR_MS;
 
 /**
- * Monday must reach back over the weekend, otherwise Friday afternoon work is
- * never reported.
+ * Monday opens the week with a recap of the whole previous one. Every other
+ * weekday reports since the last daily. The override serves local testing and
+ * does not change which of the two shapes the message takes.
  */
-export function resolveLookbackHours(now, override) {
+export function resolveWindow(now, override) {
+  const weekly = now.getUTCDay() === 1;
   const parsed = Number(override);
 
   if (Number.isFinite(parsed) && parsed > 0) {
-    return parsed;
+    return { lookbackHours: parsed, weekly };
   }
 
-  return now.getUTCDay() === 1 ? MONDAY_LOOKBACK_HOURS : DEFAULT_LOOKBACK_HOURS;
+  return {
+    lookbackHours: weekly ? WEEKLY_LOOKBACK_HOURS : DAILY_LOOKBACK_HOURS,
+    weekly,
+  };
 }
 
 export function escapeMrkdwn(text) {
@@ -197,13 +205,18 @@ function pullRequestLine(item, now, { withAge }) {
   return `• ${link(item.html_url, `#${item.number} ${item.title}`)} — _${item.user?.login ?? "?"}_${age}${marker}`;
 }
 
-export function buildBlocks(data, { repo, now, lookbackHours, comment }) {
+export function buildBlocks(
+  data,
+  { repo, now, lookbackHours, weekly, comment },
+) {
   const heading = [
     {
       type: "header",
       text: {
         type: "plain_text",
-        text: "Podsumowanie GitHub przed daily",
+        text: weekly
+          ? "Podsumowanie zeszłego tygodnia"
+          : "Podsumowanie GitHub przed daily",
         emoji: true,
       },
     },
@@ -342,13 +355,28 @@ function bearerHeaders(token) {
  * Strips the collected data down to what the comment needs. Sending whole API
  * payloads would cost tokens and add nothing.
  */
-export function summarizeForPrompt(data) {
+/**
+ * The pull request body is the author's own words about the change. It is the
+ * cheapest context that beats a title, and the tail of a long one is boilerplate
+ * from the template.
+ */
+function described(item) {
+  const body = (item.body ?? "").trim();
+
+  return {
+    title: item.title,
+    description: body ? body.slice(0, DESCRIPTION_LIMIT) : null,
+  };
+}
+
+export function summarizeForPrompt(data, { weekly } = {}) {
   const titles = (items) => items.slice(0, 10).map((item) => item.title);
 
   return {
-    merged: titles(data.merged),
+    window: weekly ? "lastWeek" : "sinceLastDaily",
+    merged: data.merged.slice(0, 10).map(described),
     awaitingReview: data.toReview.slice(0, 10).map((item) => ({
-      title: item.title,
+      ...described(item),
       createdAt: item.created_at,
     })),
     approved: titles(data.approved),
@@ -363,7 +391,7 @@ export function summarizeForPrompt(data) {
  * The comment is a nice-to-have. Any failure returns null so the summary still
  * reaches the channel.
  */
-async function requestComment(auth, data) {
+async function requestComment(auth, data, { weekly }) {
   try {
     const response = await fetch(ANTHROPIC_API, {
       method: "POST",
@@ -380,7 +408,7 @@ async function requestComment(auth, data) {
         messages: [
           {
             role: "user",
-            content: JSON.stringify(summarizeForPrompt(data)),
+            content: JSON.stringify(summarizeForPrompt(data, { weekly })),
           },
         ],
       }),
@@ -442,7 +470,10 @@ async function main() {
     : requireEnv("SLACK_WEBHOOK_URL");
 
   const now = new Date();
-  const lookbackHours = resolveLookbackHours(now, process.env.LOOKBACK_HOURS);
+  const { lookbackHours, weekly } = resolveWindow(
+    now,
+    process.env.LOOKBACK_HOURS,
+  );
   const since = new Date(now.getTime() - lookbackHours * HOUR_MS);
 
   let blocks;
@@ -455,9 +486,9 @@ async function main() {
       console.warn(auth.notice);
     }
 
-    const comment = auth ? await requestComment(auth, data) : null;
+    const comment = auth ? await requestComment(auth, data, { weekly }) : null;
 
-    blocks = buildBlocks(data, { repo, now, lookbackHours, comment });
+    blocks = buildBlocks(data, { repo, now, lookbackHours, weekly, comment });
   } catch (error) {
     // A silent channel hides the outage. Report it and still fail the workflow.
     const notice = `:warning: Nie udało się zebrać podsumowania z GitHuba: ${escapeMrkdwn(error.message)}`;
@@ -472,7 +503,9 @@ async function main() {
     throw error;
   }
 
-  const text = "Podsumowanie GitHub przed daily";
+  const text = weekly
+    ? "Podsumowanie zeszłego tygodnia"
+    : "Podsumowanie GitHub przed daily";
 
   if (dryRun) {
     console.log(JSON.stringify({ text, blocks }, null, 2));

--- a/.github/scripts/daily-summary.mjs
+++ b/.github/scripts/daily-summary.mjs
@@ -14,6 +14,8 @@ const SLACK_SECTION_LIMIT = 2900;
 
 const ANTHROPIC_API = "https://api.anthropic.com/v1/messages";
 const ANTHROPIC_VERSION = "2023-06-01";
+const ANTHROPIC_OAUTH_BETA = "oauth-2025-04-20";
+const OAUTH_TOKEN_PREFIX = "sk-ant-oat";
 const ANTHROPIC_MODEL = "claude-opus-5";
 /**
  * Adaptive thinking is on by default and its tokens count against max_tokens,
@@ -301,6 +303,42 @@ export function buildBlocks(data, { repo, now, lookbackHours, comment }) {
 }
 
 /**
+ * A subscription token from `claude setup-token` authenticates as a bearer
+ * token, not as an API key. Sending it on `x-api-key` returns 401, which is
+ * indistinguishable from a revoked key unless the caller knows the difference.
+ */
+export function resolveAuth(env) {
+  const oauthToken = env.CLAUDE_CODE_OAUTH_TOKEN;
+
+  if (oauthToken) {
+    return { headers: bearerHeaders(oauthToken) };
+  }
+
+  const apiKey = env.ANTHROPIC_API_KEY;
+
+  if (!apiKey) {
+    return null;
+  }
+
+  if (apiKey.startsWith(OAUTH_TOKEN_PREFIX)) {
+    return {
+      headers: bearerHeaders(apiKey),
+      notice:
+        "ANTHROPIC_API_KEY holds a subscription token. Move it to CLAUDE_CODE_OAUTH_TOKEN.",
+    };
+  }
+
+  return { headers: { "x-api-key": apiKey } };
+}
+
+function bearerHeaders(token) {
+  return {
+    authorization: `Bearer ${token}`,
+    "anthropic-beta": ANTHROPIC_OAUTH_BETA,
+  };
+}
+
+/**
  * Strips the collected data down to what the comment needs. Sending whole API
  * payloads would cost tokens and add nothing.
  */
@@ -325,14 +363,14 @@ export function summarizeForPrompt(data) {
  * The comment is a nice-to-have. Any failure returns null so the summary still
  * reaches the channel.
  */
-async function requestComment(apiKey, data) {
+async function requestComment(auth, data) {
   try {
     const response = await fetch(ANTHROPIC_API, {
       method: "POST",
       headers: {
         "content-type": "application/json",
-        "x-api-key": apiKey,
         "anthropic-version": ANTHROPIC_VERSION,
+        ...auth.headers,
       },
       body: JSON.stringify({
         model: ANTHROPIC_MODEL,
@@ -411,8 +449,13 @@ async function main() {
 
   try {
     const data = await collect({ repo, token, since });
-    const apiKey = process.env.ANTHROPIC_API_KEY;
-    const comment = apiKey ? await requestComment(apiKey, data) : null;
+    const auth = resolveAuth(process.env);
+
+    if (auth?.notice) {
+      console.warn(auth.notice);
+    }
+
+    const comment = auth ? await requestComment(auth, data) : null;
 
     blocks = buildBlocks(data, { repo, now, lookbackHours, comment });
   } catch (error) {

--- a/.github/scripts/daily-summary.test.mjs
+++ b/.github/scripts/daily-summary.test.mjs
@@ -6,7 +6,7 @@ import {
   escapeMrkdwn,
   formatAge,
   resolveAuth,
-  resolveLookbackHours,
+  resolveWindow,
   summarizeForPrompt,
 } from "./daily-summary.mjs";
 
@@ -42,19 +42,38 @@ function textOf(blocks) {
   return blocks.map((block) => block.text?.text ?? "").join("\n");
 }
 
-test("Monday reaches back over the weekend", () => {
-  assert.equal(resolveLookbackHours(new Date("2026-08-31T09:45:00Z")), 72);
-  assert.equal(resolveLookbackHours(new Date("2026-08-28T09:45:00Z")), 24);
+test("Monday recaps the whole previous week", () => {
+  const monday = resolveWindow(new Date("2026-08-31T09:45:00Z"));
+
+  assert.equal(monday.lookbackHours, 168);
+  assert.equal(monday.weekly, true);
 });
 
-test("an explicit lookback overrides the weekday default", () => {
+test("every other weekday reports since the last daily", () => {
+  const friday = resolveWindow(new Date("2026-08-28T09:45:00Z"));
+
+  assert.equal(friday.lookbackHours, 24);
+  assert.equal(friday.weekly, false);
+});
+
+test("an override changes the window but not the shape of the message", () => {
+  const monday = resolveWindow(new Date("2026-08-31T09:45:00Z"), "2");
+
+  assert.equal(monday.lookbackHours, 2);
+  assert.equal(monday.weekly, true);
   assert.equal(
-    resolveLookbackHours(new Date("2026-08-31T09:45:00Z"), "168"),
-    168,
-  );
-  assert.equal(
-    resolveLookbackHours(new Date("2026-08-28T09:45:00Z"), "nonsense"),
+    resolveWindow(new Date("2026-08-28T09:45:00Z"), "junk").lookbackHours,
     24,
+  );
+});
+
+test("Monday carries a different heading", () => {
+  const weekly = buildBlocks(EMPTY, { ...CONTEXT, weekly: true });
+
+  assert.equal(weekly[0].text.text, "Podsumowanie zeszłego tygodnia");
+  assert.equal(
+    buildBlocks(EMPTY, CONTEXT)[0].text.text,
+    "Podsumowanie GitHub przed daily",
   );
 });
 
@@ -206,9 +225,9 @@ test("the prompt payload carries titles and counts, not whole API objects", () =
     releases: [{ tag_name: "v1.2.3" }],
   });
 
-  assert.deepEqual(payload.merged, ["feat: a"]);
+  assert.deepEqual(payload.merged, [{ title: "feat: a", description: null }]);
   assert.deepEqual(payload.awaitingReview, [
-    { title: "fix: b", createdAt: "2026-08-01T00:00:00Z" },
+    { title: "fix: b", description: null, createdAt: "2026-08-01T00:00:00Z" },
   ]);
   assert.equal(payload.openedIssues, 2);
   assert.deepEqual(payload.releases, ["v1.2.3"]);
@@ -262,4 +281,34 @@ test("the subscription token wins when both are set", () => {
   });
 
   assert.equal(auth.headers.authorization, "Bearer sk-ant-oat01-xyz");
+});
+
+test("the prompt payload carries the pull request description", () => {
+  const payload = summarizeForPrompt({
+    ...EMPTY,
+    merged: [pullRequest({ body: "Zmienia sposób liczenia rabatu." })],
+  });
+
+  assert.equal(
+    payload.merged[0].description,
+    "Zmienia sposób liczenia rabatu.",
+  );
+});
+
+test("a long description is truncated and an empty one becomes null", () => {
+  const payload = summarizeForPrompt({
+    ...EMPTY,
+    merged: [
+      pullRequest({ body: "x".repeat(2000) }),
+      pullRequest({ body: "   " }),
+    ],
+  });
+
+  assert.equal(payload.merged[0].description.length, 600);
+  assert.equal(payload.merged[1].description, null);
+});
+
+test("the prompt payload names the window", () => {
+  assert.equal(summarizeForPrompt(EMPTY, { weekly: true }).window, "lastWeek");
+  assert.equal(summarizeForPrompt(EMPTY).window, "sinceLastDaily");
 });

--- a/.github/scripts/daily-summary.test.mjs
+++ b/.github/scripts/daily-summary.test.mjs
@@ -5,6 +5,7 @@ import {
   buildBlocks,
   escapeMrkdwn,
   formatAge,
+  resolveAuth,
   resolveLookbackHours,
   summarizeForPrompt,
 } from "./daily-summary.mjs";
@@ -225,4 +226,40 @@ test("the prompt payload caps each list at ten entries", () => {
 
   assert.equal(payload.merged.length, 10);
   assert.equal(payload.awaitingReview.length, 10);
+});
+
+test("no credential means no request", () => {
+  assert.equal(resolveAuth({}), null);
+});
+
+test("an API key authenticates on x-api-key", () => {
+  const auth = resolveAuth({ ANTHROPIC_API_KEY: "sk-ant-api03-abc" });
+
+  assert.equal(auth.headers["x-api-key"], "sk-ant-api03-abc");
+  assert.equal(auth.headers.authorization, undefined);
+  assert.equal(auth.notice, undefined);
+});
+
+test("a subscription token authenticates as a bearer token", () => {
+  const auth = resolveAuth({ CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-abc" });
+
+  assert.equal(auth.headers.authorization, "Bearer sk-ant-oat01-abc");
+  assert.equal(auth.headers["anthropic-beta"], "oauth-2025-04-20");
+  assert.equal(auth.headers["x-api-key"], undefined);
+});
+
+test("a subscription token under the API key name still works, with a notice", () => {
+  const auth = resolveAuth({ ANTHROPIC_API_KEY: "sk-ant-oat01-abc" });
+
+  assert.equal(auth.headers.authorization, "Bearer sk-ant-oat01-abc");
+  assert.match(auth.notice, /CLAUDE_CODE_OAUTH_TOKEN/);
+});
+
+test("the subscription token wins when both are set", () => {
+  const auth = resolveAuth({
+    ANTHROPIC_API_KEY: "sk-ant-api03-abc",
+    CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-xyz",
+  });
+
+  assert.equal(auth.headers.authorization, "Bearer sk-ant-oat01-xyz");
 });

--- a/.github/workflows/daily-summary.yaml
+++ b/.github/workflows/daily-summary.yaml
@@ -56,7 +56,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          # Optional. Without it the summary posts without the Claude comment.
+          # Both are optional. Without either, the summary posts without the
+          # Claude comment. Set one: an API key from the Anthropic console, or a
+          # subscription token from `claude setup-token`.
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: node .github/scripts/daily-summary.mjs

--- a/llm-wiki/operations/OPS-0009 Daily GitHub Summary Bot.md
+++ b/llm-wiki/operations/OPS-0009 Daily GitHub Summary Bot.md
@@ -25,7 +25,10 @@ delivery time, to rotate the Slack webhook, or to diagnose a missing message on 
 channel.
 
 The bot posts one message at 09:45 Europe/Warsaw, Monday to Friday, 15 minutes before the
-daily meeting. The message lists pull requests merged since the previous daily, open pull
+daily meeting. It does not run at the weekend.
+
+Monday opens the week with a recap of the whole previous week and a heading that says so. Every
+other weekday reports the activity since the previous daily. The message lists pull requests merged since the previous daily, open pull
 requests waiting for review, failed `Linters & Tests` runs on `main`, and issue and release
 activity.
 
@@ -59,6 +62,10 @@ to the repository and do not paste it into an issue or a pull request.
    and one hour for the winter entry.
 4. Update the hour in the `Check the local hour` step to match the new local hour.
 
+The cron entries end in `1-5`, which is Monday to Friday. Do not widen that range without
+changing `resolveWindow`, because the Monday recap assumes that no message went out at the
+weekend.
+
 The guard step compares the hour, not the minute. GitHub can delay a scheduled run by several
 minutes and a minute-exact guard would drop valid runs.
 
@@ -84,9 +91,10 @@ selects the right one. A subscription token pasted under `ANTHROPIC_API_KEY` sti
 because the script recognizes the `sk-ant-oat` prefix, but it logs a notice asking you to move
 it. When both secrets are set, the subscription token wins.
 
-The bot sends one request per weekday. It uses the model `claude-opus-5` at effort `low`, and
-it trims the data to titles and counts before the request, so one run costs a fraction of a
-cent. To drop the comment and keep the sections, delete the credential secret. No code change is
+The bot sends one request per weekday. It uses the model `claude-opus-5` at effort `low`. Before
+the request it trims the data to titles, pull request descriptions, and counts. A description is
+cut at 600 characters, and each list is capped at ten entries, so one run costs a fraction of a
+cent. Monday costs more than the other days, because a weekly window holds more pull requests. To drop the comment and keep the sections, delete the credential secret. No code change is
 needed.
 
 ## Change the summary content

--- a/llm-wiki/operations/OPS-0009 Daily GitHub Summary Bot.md
+++ b/llm-wiki/operations/OPS-0009 Daily GitHub Summary Bot.md
@@ -62,17 +62,32 @@ to the repository and do not paste it into an issue or a pull request.
 The guard step compares the hour, not the minute. GitHub can delay a scheduled run by several
 minutes and a minute-exact guard would drop valid runs.
 
-## Install the Claude API key
+## Install the Claude credential
 
-The comment above the sections is optional. Without the key the bot posts the sections alone.
+The comment above the sections is optional. Without a credential the bot posts the sections
+alone. Two kinds of credential work. Choose one.
 
-1. Open the Anthropic console and create an API key.
+An API key bills the organization and does not depend on one person:
+
+1. Open the Anthropic console and create an API key. It starts with `sk-ant-api`.
 2. In GitHub, open Settings, then Secrets and variables, then Actions.
 3. Add a repository secret named `ANTHROPIC_API_KEY` and paste the key.
 
+A subscription token bills the plan of the person who created it, and it lasts one year:
+
+1. Run `claude setup-token` in a terminal. The token prints to the screen and is saved nowhere.
+2. Add a repository secret named `CLAUDE_CODE_OAUTH_TOKEN` and paste the token.
+
+The two kinds authenticate differently. An API key goes on the `x-api-key` header. A
+subscription token goes on `Authorization: Bearer` with the `anthropic-beta` header. The script
+selects the right one. A subscription token pasted under `ANTHROPIC_API_KEY` still works,
+because the script recognizes the `sk-ant-oat` prefix, but it logs a notice asking you to move
+it. When both secrets are set, the subscription token wins.
+
 The bot sends one request per weekday. It uses the model `claude-opus-5` at effort `low`, and
 it trims the data to titles and counts before the request, so one run costs a fraction of a
-cent. To drop the comment and keep the sections, delete the secret. No code change is needed.
+cent. To drop the comment and keep the sections, delete the credential secret. No code change is
+needed.
 
 ## Change the summary content
 
@@ -130,7 +145,11 @@ If the message arrives without the comment above the sections, the sections are 
 only the Claude call failed. Read the `Post summary` step for a `Claude` warning line:
 
 - No warning line means that `ANTHROPIC_API_KEY` is absent. The bot skipped the call.
-- `Claude 401` means that the key is wrong or revoked.
+- `Claude 401` with `API key is invalid` means that the API key is wrong or revoked. If you
+  pasted the output of `claude setup-token` under `ANTHROPIC_API_KEY`, move it to
+  `CLAUDE_CODE_OAUTH_TOKEN`.
+- `Claude 401` with `OAuth access token is invalid` means that the subscription token expired
+  or was revoked. Run `claude setup-token` again and replace the secret.
 - `Claude 429` means that the account hit its Anthropic rate limit.
 
 A failed comment never blocks the summary, so the job still succeeds. This is intended. The


### PR DESCRIPTION
The daily summary posted without its comment. The job log held the reason:

```
Claude 401: {"type":"error","error":{"type":"authentication_error","message":"API key is invalid."}}
Posted 6 blocks for the last 24 hours.
```

Run: https://github.com/mirumee/nimara-ecommerce/actions/runs/33162508783

## Cause

A subscription token from `claude setup-token` and an API key from the Anthropic console are
different credentials with different headers:

| Credential | Prefix | Header |
| --- | --- | --- |
| API key | `sk-ant-api` | `x-api-key` |
| Subscription token | `sk-ant-oat` | `Authorization: Bearer` plus `anthropic-beta` |

The script sent everything on `x-api-key`. A subscription token pasted into
`ANTHROPIC_API_KEY` therefore returns 401, and the message reads `API key is invalid`, which
looks the same as a revoked key.

## Fix

`resolveAuth` picks the header set:

1. `CLAUDE_CODE_OAUTH_TOKEN` wins when it is set, and authenticates as a bearer token.
2. `ANTHROPIC_API_KEY` starting with `sk-ant-oat` is recognized as a misplaced subscription
   token. It still works, and the job logs a notice asking for the secret to be moved.
3. Any other `ANTHROPIC_API_KEY` authenticates on `x-api-key`.
4. Neither set means no request, and the summary posts without a comment as before.

The workflow now passes both secrets. Either one alone is enough.

## Testing

`node --test ".github/scripts/*.test.mjs"` passes 22 tests, 5 of them new: no credential, an
API key on `x-api-key`, a subscription token as a bearer token, a misplaced subscription token
with its notice, and the precedence when both are set.

Verified against the live API endpoint with a dry run. A fake `sk-ant-oat01-` value under
`ANTHROPIC_API_KEY` produced:

```
ANTHROPIC_API_KEY holds a subscription token. Move it to CLAUDE_CODE_OAUTH_TOKEN.
Claude 401: {"error":{"message":"OAuth access token is invalid."}}
```

The error text changed from `API key is invalid` to `OAuth access token is invalid`, which
proves the request now travels the bearer path. A real token completes it.

The summary itself still posts in every failure case.

## What the operator must do

If the current secret holds the output of `claude setup-token`, add it as
`CLAUDE_CODE_OAUTH_TOKEN` and delete `ANTHROPIC_API_KEY`. If it holds a console API key, the
key is invalid and needs replacing.

## Documentation

`llm-wiki/operations/OPS-0009 Daily GitHub Summary Bot.md` now covers both credential types and
tells the two `401` messages apart.

# Pull Request Checklist

- [x] Target `main` from a short-lived change branch and use a Conventional Commit PR title.
- [x] Test the changes locally to ensure they work as expected.
- [x] Document the testing process and results in the pull request description.
- [ ] Verify all four Vercel project statuses: `nimara-docs`, `nimara-ecommerce`,
      `nimara-ecommerce-stripe`, and `nimara-marketplace`.
- [x] Include new tests for any new functionality or significant changes.
- [x] Ensure that tests cover edge cases and potential failure points.
- [x] Keep incomplete behavior disabled with a short-lived feature flag or branch-by-abstraction seam.
- [x] Document the impact of the changes on the system, including potential risks and benefits.
- [x] Provide a rollback plan in case the changes introduce critical issues.
- [x] Update documentation to reflect any changes in functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
