### PR TITLE
feat(ci): generate the daily summary comment with the Claude Code CLI

### DIFF
--- a/.github/scripts/daily-summary.mjs
+++ b/.github/scripts/daily-summary.mjs
@@ -1,3 +1,9 @@
+import { execFile } from "node:child_process";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
 /**
  * Collects the GitHub activity since the previous daily and posts one Block Kit
  * message to a Slack Incoming Webhook.
@@ -13,19 +19,17 @@ const WEEKLY_LOOKBACK_HOURS = 168;
 const DESCRIPTION_LIMIT = 600;
 const SLACK_SECTION_LIMIT = 2900;
 
-const ANTHROPIC_API = "https://api.anthropic.com/v1/messages";
-const ANTHROPIC_VERSION = "2023-06-01";
-const ANTHROPIC_OAUTH_BETA = "oauth-2025-04-20";
-const OAUTH_TOKEN_PREFIX = "sk-ant-oat";
-const ANTHROPIC_MODEL = "claude-opus-5";
+const CLAUDE_MODEL = "claude-opus-5";
+const CLAUDE_TIMEOUT_MS = 180_000;
 /**
- * Adaptive thinking is on by default and its tokens count against max_tokens,
- * so a two-sentence answer still needs headroom.
+ * The JSON envelope carries the whole usage report, so the default 1 MB buffer
+ * is too tight to rely on.
  */
-const ANTHROPIC_MAX_TOKENS = 4000;
+const CLAUDE_MAX_BUFFER = 10 * 1024 * 1024;
 const COMMENT_SYSTEM_PROMPT = [
   "Jesteś częścią bota, który wysyła zespołowi podsumowanie GitHuba przed daily.",
   "Dostajesz dane w JSON i piszesz jedno lub dwa zdania po polsku.",
+  "Zmieść się w 300 znakach. Krótkie zdanie jest lepsze od długiego.",
   "Pole window mówi, czy podsumowujesz jeden dzień, czy cały zeszły tydzień.",
   "Pole description to opis PR-a napisany przez autora. Bywa puste.",
   "Napisz, na co zespół ma zwrócić uwagę na dzisiejszym daily.",
@@ -316,46 +320,6 @@ export function buildBlocks(
 }
 
 /**
- * A subscription token from `claude setup-token` authenticates as a bearer
- * token, not as an API key. Sending it on `x-api-key` returns 401, which is
- * indistinguishable from a revoked key unless the caller knows the difference.
- */
-export function resolveAuth(env) {
-  const oauthToken = env.CLAUDE_CODE_OAUTH_TOKEN;
-
-  if (oauthToken) {
-    return { headers: bearerHeaders(oauthToken) };
-  }
-
-  const apiKey = env.ANTHROPIC_API_KEY;
-
-  if (!apiKey) {
-    return null;
-  }
-
-  if (apiKey.startsWith(OAUTH_TOKEN_PREFIX)) {
-    return {
-      headers: bearerHeaders(apiKey),
-      notice:
-        "ANTHROPIC_API_KEY holds a subscription token. Move it to CLAUDE_CODE_OAUTH_TOKEN.",
-    };
-  }
-
-  return { headers: { "x-api-key": apiKey } };
-}
-
-function bearerHeaders(token) {
-  return {
-    authorization: `Bearer ${token}`,
-    "anthropic-beta": ANTHROPIC_OAUTH_BETA,
-  };
-}
-
-/**
- * Strips the collected data down to what the comment needs. Sending whole API
- * payloads would cost tokens and add nothing.
- */
-/**
  * The pull request body is the author's own words about the change. It is the
  * cheapest context that beats a title, and the tail of a long one is boilerplate
  * from the template.
@@ -387,54 +351,74 @@ export function summarizeForPrompt(data, { weekly } = {}) {
   };
 }
 
+const execFileAsync = promisify(execFile);
+
 /**
+ * Runs Claude Code in headless mode. The subscription token from
+ * `claude setup-token` authenticates Claude Code, not a hand-written HTTP
+ * client, so the CLI is the supported way to spend a subscription here.
+ *
  * The comment is a nice-to-have. Any failure returns null so the summary still
  * reaches the channel.
  */
-async function requestComment(auth, data, { weekly }) {
+async function requestComment(data, { weekly }) {
   try {
-    const response = await fetch(ANTHROPIC_API, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "anthropic-version": ANTHROPIC_VERSION,
-        ...auth.headers,
-      },
-      body: JSON.stringify({
-        model: ANTHROPIC_MODEL,
-        max_tokens: ANTHROPIC_MAX_TOKENS,
-        output_config: { effort: "low" },
-        system: COMMENT_SYSTEM_PROMPT,
-        messages: [
-          {
-            role: "user",
-            content: JSON.stringify(summarizeForPrompt(data, { weekly })),
-          },
-        ],
-      }),
-    });
+    // An empty directory keeps the repository's CLAUDE.md, settings, and hooks
+    // out of a session that only has to rewrite one JSON payload.
+    const cwd = await mkdtemp(join(tmpdir(), "daily-summary-"));
 
-    if (!response.ok) {
-      console.warn(
-        `Claude ${response.status}: ${(await response.text()).slice(0, 200)}`,
-      );
+    const { stdout } = await execFileAsync(
+      "claude",
+      [
+        "--print",
+        JSON.stringify(summarizeForPrompt(data, { weekly })),
+        "--system-prompt",
+        COMMENT_SYSTEM_PROMPT,
+        "--model",
+        CLAUDE_MODEL,
+        "--output-format",
+        "json",
+        "--max-turns",
+        "1",
+        "--restricted",
+      ],
+      { cwd, timeout: CLAUDE_TIMEOUT_MS, maxBuffer: CLAUDE_MAX_BUFFER },
+    );
 
-      return null;
-    }
-
-    const body = await response.json();
-    const text = (body.content ?? [])
-      .filter((block) => block.type === "text")
-      .map((block) => block.text)
-      .join(" ")
-      .trim();
-
-    return text || null;
+    return readComment(stdout);
   } catch (error) {
     console.warn(`Claude comment skipped: ${error.message}`);
 
     return null;
   }
+}
+
+/**
+ * The envelope reports its own failures in `is_error` rather than by a non-zero
+ * exit code, so a successful process is not yet a usable answer.
+ */
+export function readComment(stdout) {
+  let envelope;
+
+  try {
+    envelope = JSON.parse(stdout);
+  } catch {
+    console.warn("Claude returned output that is not JSON.");
+
+    return null;
+  }
+
+  if (envelope.is_error || envelope.subtype !== "success") {
+    console.warn(
+      `Claude reported ${envelope.subtype ?? "an error"}: ${envelope.api_error_status ?? "no status"}`,
+    );
+
+    return null;
+  }
+
+  const comment = (envelope.result ?? "").trim();
+
+  return comment || null;
 }
 
 async function postToSlack(webhookUrl, { blocks, text }) {
@@ -480,13 +464,7 @@ async function main() {
 
   try {
     const data = await collect({ repo, token, since });
-    const auth = resolveAuth(process.env);
-
-    if (auth?.notice) {
-      console.warn(auth.notice);
-    }
-
-    const comment = auth ? await requestComment(auth, data, { weekly }) : null;
+    const comment = await requestComment(data, { weekly });
 
     blocks = buildBlocks(data, { repo, now, lookbackHours, weekly, comment });
   } catch (error) {

--- a/.github/scripts/daily-summary.test.mjs
+++ b/.github/scripts/daily-summary.test.mjs
@@ -5,7 +5,7 @@ import {
   buildBlocks,
   escapeMrkdwn,
   formatAge,
-  resolveAuth,
+  readComment,
   resolveWindow,
   summarizeForPrompt,
 } from "./daily-summary.mjs";
@@ -247,42 +247,6 @@ test("the prompt payload caps each list at ten entries", () => {
   assert.equal(payload.awaitingReview.length, 10);
 });
 
-test("no credential means no request", () => {
-  assert.equal(resolveAuth({}), null);
-});
-
-test("an API key authenticates on x-api-key", () => {
-  const auth = resolveAuth({ ANTHROPIC_API_KEY: "sk-ant-api03-abc" });
-
-  assert.equal(auth.headers["x-api-key"], "sk-ant-api03-abc");
-  assert.equal(auth.headers.authorization, undefined);
-  assert.equal(auth.notice, undefined);
-});
-
-test("a subscription token authenticates as a bearer token", () => {
-  const auth = resolveAuth({ CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-abc" });
-
-  assert.equal(auth.headers.authorization, "Bearer sk-ant-oat01-abc");
-  assert.equal(auth.headers["anthropic-beta"], "oauth-2025-04-20");
-  assert.equal(auth.headers["x-api-key"], undefined);
-});
-
-test("a subscription token under the API key name still works, with a notice", () => {
-  const auth = resolveAuth({ ANTHROPIC_API_KEY: "sk-ant-oat01-abc" });
-
-  assert.equal(auth.headers.authorization, "Bearer sk-ant-oat01-abc");
-  assert.match(auth.notice, /CLAUDE_CODE_OAUTH_TOKEN/);
-});
-
-test("the subscription token wins when both are set", () => {
-  const auth = resolveAuth({
-    ANTHROPIC_API_KEY: "sk-ant-api03-abc",
-    CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-xyz",
-  });
-
-  assert.equal(auth.headers.authorization, "Bearer sk-ant-oat01-xyz");
-});
-
 test("the prompt payload carries the pull request description", () => {
   const payload = summarizeForPrompt({
     ...EMPTY,
@@ -311,4 +275,38 @@ test("a long description is truncated and an empty one becomes null", () => {
 test("the prompt payload names the window", () => {
   assert.equal(summarizeForPrompt(EMPTY, { weekly: true }).window, "lastWeek");
   assert.equal(summarizeForPrompt(EMPTY).window, "sinceLastDaily");
+});
+
+test("a successful envelope yields the comment", () => {
+  const comment = readComment(
+    JSON.stringify({
+      subtype: "success",
+      is_error: false,
+      result: "  Spokojny tydzień.  ",
+    }),
+  );
+
+  assert.equal(comment, "Spokojny tydzień.");
+});
+
+test("an envelope that reports an error yields no comment", () => {
+  assert.equal(
+    readComment(
+      JSON.stringify({ subtype: "error_during_execution", is_error: true }),
+    ),
+    null,
+  );
+});
+
+test("a successful envelope with an empty result yields no comment", () => {
+  assert.equal(
+    readComment(
+      JSON.stringify({ subtype: "success", is_error: false, result: "   " }),
+    ),
+    null,
+  );
+});
+
+test("output that is not JSON yields no comment", () => {
+  assert.equal(readComment("command not found: claude"), null);
 });

--- a/.github/workflows/daily-summary.yaml
+++ b/.github/workflows/daily-summary.yaml
@@ -51,15 +51,22 @@ jobs:
         with:
           node-version: "lts/krypton"
 
+      # The subscription token authenticates Claude Code, not a hand-written
+      # HTTP client, so the summary calls the CLI for its comment.
+      - name: Install Claude Code
+        if: steps.guard.outputs.run == 'true'
+        run: npm install -g @anthropic-ai/claude-code@2.1.250
+
       - name: Post summary
         if: steps.guard.outputs.run == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          # Both are optional. Without either, the summary posts without the
-          # Claude comment. Set one: an API key from the Anthropic console, or a
-          # subscription token from `claude setup-token`.
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Both are optional and the CLI selects between them. Without either,
+          # the summary posts without the Claude comment. Set one: a
+          # subscription token from `claude setup-token`, or an API key from the
+          # Anthropic console.
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: node .github/scripts/daily-summary.mjs

--- a/llm-wiki/operations/OPS-0009 Daily GitHub Summary Bot.md
+++ b/llm-wiki/operations/OPS-0009 Daily GitHub Summary Bot.md
@@ -85,16 +85,26 @@ A subscription token bills the plan of the person who created it, and it lasts o
 1. Run `claude setup-token` in a terminal. The token prints to the screen and is saved nowhere.
 2. Add a repository secret named `CLAUDE_CODE_OAUTH_TOKEN` and paste the token.
 
-The two kinds authenticate differently. An API key goes on the `x-api-key` header. A
-subscription token goes on `Authorization: Bearer` with the `anthropic-beta` header. The script
-selects the right one. A subscription token pasted under `ANTHROPIC_API_KEY` still works,
-because the script recognizes the `sk-ant-oat` prefix, but it logs a notice asking you to move
-it. When both secrets are set, the subscription token wins.
+The script does not call the API itself. It runs Claude Code in headless mode, and the CLI
+selects between the two credentials. A subscription token authenticates Claude Code, not a
+hand-written HTTP client: a direct call to the Messages API with one returns `429` with the
+unhelpful body `{"type":"rate_limit_error","message":"Error"}`, which reads like an exhausted
+quota but is not one.
 
-The bot sends one request per weekday. It uses the model `claude-opus-5` at effort `low`. Before
-the request it trims the data to titles, pull request descriptions, and counts. A description is
-cut at 600 characters, and each list is capped at ten entries, so one run costs a fraction of a
-cent. Monday costs more than the other days, because a weekly window holds more pull requests. To drop the comment and keep the sections, delete the credential secret. No code change is
+The workflow installs the CLI with a pinned version. Raise that pin deliberately, not on a
+schedule, because the harness changes what a session costs.
+
+The bot runs one session per weekday with the model `claude-opus-5`. Before the session it trims
+the data to titles, pull request descriptions, and counts. A description is cut at 600
+characters and each list is capped at ten entries.
+
+Claude Code sends its own harness context on every session, about 12,000 input tokens, which
+dominates the cost. One run bills around 13 cents at list price, and Monday costs more because a
+weekly window holds more pull requests. On a subscription token this is charged against the
+plan's limits rather than in dollars.
+
+`--bare` would drop most of that context, but it does not read `CLAUDE_CODE_OAUTH_TOKEN`. It is
+usable only with an API key. To drop the comment and keep the sections, delete the credential secret. No code change is
 needed.
 
 ## Change the summary content
@@ -153,11 +163,12 @@ If the message arrives without the comment above the sections, the sections are 
 only the Claude call failed. Read the `Post summary` step for a `Claude` warning line:
 
 - No warning line means that `ANTHROPIC_API_KEY` is absent. The bot skipped the call.
-- `Claude 401` with `API key is invalid` means that the API key is wrong or revoked. If you
-  pasted the output of `claude setup-token` under `ANTHROPIC_API_KEY`, move it to
-  `CLAUDE_CODE_OAUTH_TOKEN`.
-- `Claude 401` with `OAuth access token is invalid` means that the subscription token expired
-  or was revoked. Run `claude setup-token` again and replace the secret.
+- `Claude comment skipped: ... ENOENT` means that the `Install Claude Code` step did not run or
+  did not finish.
+- `Claude comment skipped: ... timed out` means that the session ran past three minutes.
+- `Claude reported error_during_execution` means that the session started and failed. The
+  credential is the first thing to check: an expired subscription token needs
+  `claude setup-token` run again, and a revoked API key needs replacing.
 - `Claude 429` means that the account hit its Anthropic rate limit.
 
 A failed comment never blocks the summary, so the job still succeeds. This is intended. The


### PR DESCRIPTION
## Why

The comment stopped arriving with `Claude 429: {"type":"rate_limit_error","message":"Error"}`.
That reads like an exhausted subscription quota. It was not one: the same subscription kept
serving interactive Claude Code sessions at the same moment.

The documentation scopes `CLAUDE_CODE_OAUTH_TOKEN` to "the CLI and the surfaces that wrap it,
including the VS Code extension, the Agent SDK, and GitHub Actions". Our script was none of
those. It was a hand-written HTTP client holding a credential meant to authenticate Claude Code.

## What changed

`requestComment` runs `claude --print` and reads `result` from the JSON envelope.

- The CLI selects between `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_API_KEY`, so `resolveAuth`,
  `bearerHeaders`, and the hand-built headers from #803 are deleted.
- The session runs in an empty temporary directory. The repository's `CLAUDE.md`, settings, and
  hooks have no business in a task that rewrites one JSON payload.
- `--restricted` removes the tools that run commands. `--max-turns 1` stops a loop.
- `readComment` is a separate pure function, because the envelope reports its own failures in
  `is_error` rather than by a non-zero exit code. A successful process is not yet an answer.
- The workflow installs `@anthropic-ai/claude-code@2.1.250`, pinned.

`--bare` would cut most of the harness context, but it does not read `CLAUDE_CODE_OAUTH_TOKEN`.
It is usable only with an API key.

## Cost, measured

| | `claude --print` | the direct call it replaces |
| --- | --- | --- |
| Input tokens | 12,031 | ~500 |
| List price per run | $0.126 | ~$0.003 |

Claude Code sends its own harness context on every session even with `--system-prompt`, and that
dominates the cost. On a subscription token this is charged against the plan's limits rather
than in dollars. One session per weekday.

This is the price of using a subscription. An API key would make the direct call viable again at
a fortieth of the cost.

## The comment got a length cap

The first live run produced two sentences running past 500 characters. The prompt now caps it at
300. Live runs since:

> _Warto obgadać PR na wiki QA — czeka na review od 10 sierpnia i nikt go nie ruszył. Poza tym
> spokojnie: CI zielone, dwa PR-y zaakceptowane czekają tylko na merge._

An earlier run named an open question about shipping zones that appears only in a pull request
body, which confirms the descriptions reach the model.

## Testing

`node --test ".github/scripts/*.test.mjs"` passes 26 tests. The five `resolveAuth` tests are
replaced by four for `readComment`: a successful envelope, an envelope reporting an error, a
success with an empty result, and output that is not JSON.

Verified end to end locally against live GitHub data with real CLI sessions. The message held 7
blocks with the comment above the sections.

`pnpm wiki:lint` reports zero violations across 97 files.

## Rollback

Delete the credential secret to keep the summary without the comment. To go back to the direct
API call, revert this pull request and use an API key.

# Pull Request Checklist

- [x] Target `main` from a short-lived change branch and use a Conventional Commit PR title.
- [x] Test the changes locally to ensure they work as expected.
- [x] Document the testing process and results in the pull request description.
- [ ] Verify all four Vercel project statuses: `nimara-docs`, `nimara-ecommerce`,
      `nimara-ecommerce-stripe`, and `nimara-marketplace`.
- [x] Include new tests for any new functionality or significant changes.
- [x] Ensure that tests cover edge cases and potential failure points.
- [x] Keep incomplete behavior disabled with a short-lived feature flag or branch-by-abstraction seam.
- [x] Document the impact of the changes on the system, including potential risks and benefits.
- [x] Provide a rollback plan in case the changes introduce critical issues.
- [x] Update documentation to reflect any changes in functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
