### PR TITLE
feat(ci): order the daily summary by who owns the next move

### DIFF
--- a/.github/scripts/daily-summary.mjs
+++ b/.github/scripts/daily-summary.mjs
@@ -13,10 +13,17 @@ import { promisify } from "node:util";
 
 const GITHUB_API = "https://api.github.com";
 const MAX_LIST_ITEMS = 10;
-const STALE_PR_DAYS = 2;
+/**
+ * The median pull request in this repository merges the day it opens, so two
+ * days already marks an outlier and five days means parked rather than in
+ * flight.
+ */
+const WARN_PR_DAYS = 2;
+const PARKED_PR_DAYS = 5;
 const DAILY_LOOKBACK_HOURS = 24;
 const WEEKLY_LOOKBACK_HOURS = 168;
 const DESCRIPTION_LIMIT = 600;
+const MAX_RELEASES_SHOWN = 2;
 const SLACK_SECTION_LIMIT = 2900;
 
 const CLAUDE_MODEL = "claude-opus-5";
@@ -30,12 +37,18 @@ const COMMENT_SYSTEM_PROMPT = [
   "Jesteś częścią bota, który wysyła zespołowi podsumowanie GitHuba przed daily.",
   "Dostajesz dane w JSON i piszesz jedno lub dwa zdania po polsku.",
   "Zmieść się w 300 znakach. Krótkie zdanie jest lepsze od długiego.",
+  "Dane są pogrupowane po tym, kto wykonuje następny ruch.",
+  "redCiOnMain blokuje wszystkich. blockedOnAuthor czeka na autora.",
+  "unclaimed to PR-y, których nikt nie wziął do review.",
+  "readyToMerge czeka tylko na kliknięcie merge.",
+  "parked to PR-y odstawione od dawna, których nie ma w sekcjach wiadomości.",
+  "Możesz wspomnieć najwyżej jeden odstawiony PR, gdy naprawdę wymaga decyzji.",
   "Pole window mówi, czy podsumowujesz jeden dzień, czy cały zeszły tydzień.",
   "Pole description to opis PR-a napisany przez autora. Bywa puste.",
-  "Napisz, na co zespół ma zwrócić uwagę na dzisiejszym daily.",
-  "Nie powtarzaj liczb, które i tak są w sekcjach poniżej.",
+  "Napisz, co zespół ma rozstrzygnąć na dzisiejszym daily. Wskaż osobę, gdy to pomaga.",
+  "Nie powtarzaj liczb ani tytułów, które i tak są w sekcjach poniżej.",
   "Nie witaj się, nie podsumowuj danych, nie używaj emoji ani list.",
-  "Gdy nic nie wymaga uwagi, napisz jedno zdanie, że dzień jest spokojny.",
+  "Gdy nic nie czeka na ruch, napisz jedno zdanie, że dzień jest spokojny.",
 ].join(" ");
 
 /**
@@ -153,12 +166,49 @@ function dedupeRuns(runs) {
   return [...newest.values()];
 }
 
+/**
+ * Every open pull request has exactly one owner of the next move. A red build or
+ * a requested change puts the ball with the author and outranks an approval,
+ * because nobody should merge a pull request whose checks are failing.
+ */
+export function classifyOpenPullRequests({
+  unreviewed,
+  changesRequested,
+  failingChecks,
+  approved,
+}) {
+  const authorsTurn = new Map();
+
+  for (const [items, reason] of [
+    [failingChecks, "CI czerwone"],
+    [changesRequested, "zmiany do poprawy"],
+  ]) {
+    for (const item of items) {
+      if (!authorsTurn.has(item.number)) {
+        authorsTurn.set(item.number, { ...item, reason });
+      }
+    }
+  }
+
+  const claimed = new Set(authorsTurn.keys());
+
+  return {
+    blockedOnAuthor: [...authorsTurn.values()],
+    unclaimed: unreviewed.filter((item) => !claimed.has(item.number)),
+    readyToMerge: approved.filter((item) => !claimed.has(item.number)),
+  };
+}
+
 async function collect({ repo, token, since }) {
   const sinceQuery = since.toISOString().replace(/\.\d{3}Z$/, "Z");
 
+  const open = "is:pr is:open draft:false";
+
   const [
     merged,
-    toReview,
+    unreviewed,
+    changesRequested,
+    failingChecks,
     approved,
     runs,
     openedIssues,
@@ -166,8 +216,10 @@ async function collect({ repo, token, since }) {
     releases,
   ] = await Promise.all([
     search(repo, token, `is:pr is:merged merged:>=${sinceQuery}`),
-    search(repo, token, "is:pr is:open draft:false review:none"),
-    search(repo, token, "is:pr is:open draft:false review:approved"),
+    search(repo, token, `${open} review:none`),
+    search(repo, token, `${open} review:changes_requested`),
+    search(repo, token, `${open} status:failure`),
+    search(repo, token, `${open} review:approved`),
     githubRequest(
       `/repos/${repo}/actions/runs?branch=main&status=failure&per_page=20`,
       token,
@@ -179,8 +231,12 @@ async function collect({ repo, token, since }) {
 
   return {
     merged,
-    toReview,
-    approved,
+    ...classifyOpenPullRequests({
+      unreviewed,
+      changesRequested,
+      failingChecks,
+      approved,
+    }),
     failedRuns: dedupeRuns(
       (runs.workflow_runs ?? []).filter(
         (run) =>
@@ -197,16 +253,57 @@ async function collect({ repo, token, since }) {
   };
 }
 
-function pullRequestLine(item, now, { withAge }) {
-  const marker =
-    withAge &&
-    now.getTime() - new Date(item.created_at).getTime() >=
-      STALE_PR_DAYS * DAY_MS
-      ? " :hourglass:"
-      : "";
-  const age = withAge ? ` · ${formatAge(item.created_at, now)}` : "";
+/**
+ * Parked pull requests repeat every morning and turn the message into wallpaper.
+ * The daily message counts them; Monday lists them.
+ */
+export function ageBucket(isoDate, now) {
+  const days = (now.getTime() - new Date(isoDate).getTime()) / DAY_MS;
 
-  return `• ${link(item.html_url, `#${item.number} ${item.title}`)} — _${item.user?.login ?? "?"}_${age}${marker}`;
+  if (days >= PARKED_PR_DAYS) {
+    return "parked";
+  }
+
+  return days >= WARN_PR_DAYS ? "warn" : "fresh";
+}
+
+function splitParked(items, now, weekly) {
+  if (weekly) {
+    return { shown: items, parked: 0 };
+  }
+
+  const shown = items.filter(
+    (item) => ageBucket(item.created_at, now) !== "parked",
+  );
+
+  return { shown, parked: items.length - shown.length };
+}
+
+function pullRequestLine(item, now) {
+  const marker =
+    ageBucket(item.created_at, now) === "fresh" ? "" : " :small_red_triangle:";
+  const reason = item.reason ? ` — ${item.reason}` : "";
+
+  return (
+    `• ${link(item.html_url, `#${item.number} ${item.title}`)}` +
+    ` — _${item.user?.login ?? "?"}_${reason} · ${formatAge(item.created_at, now)}${marker}`
+  );
+}
+
+function queueSection(title, items, now, weekly) {
+  const { shown, parked } = splitParked(items, now, weekly);
+
+  if (shown.length === 0) {
+    return { block: null, parked };
+  }
+
+  return {
+    block: section(
+      `*${title} (${shown.length})*\n` +
+        bulletList(shown.map((item) => pullRequestLine(item, now))),
+    ),
+    parked,
+  };
 }
 
 export function buildBlocks(
@@ -235,51 +332,16 @@ export function buildBlocks(
     },
   ];
 
+  if (comment) {
+    heading.push(section(`_${escapeMrkdwn(comment)}_`));
+  }
+
   const blocks = [];
-
-  if (data.merged.length > 0) {
-    blocks.push(
-      section(
-        `*:white_check_mark: Zmergowane do main (${data.merged.length})*\n` +
-          bulletList(
-            data.merged.map((item) =>
-              pullRequestLine(item, now, { withAge: false }),
-            ),
-          ),
-      ),
-    );
-  }
-
-  if (data.toReview.length > 0) {
-    blocks.push(
-      section(
-        `*:eyes: Czekają na review (${data.toReview.length})*\n` +
-          bulletList(
-            data.toReview.map((item) =>
-              pullRequestLine(item, now, { withAge: true }),
-            ),
-          ),
-      ),
-    );
-  }
-
-  if (data.approved.length > 0) {
-    blocks.push(
-      section(
-        `*:rocket: Zaakceptowane, do merge (${data.approved.length})*\n` +
-          bulletList(
-            data.approved.map((item) =>
-              pullRequestLine(item, now, { withAge: true }),
-            ),
-          ),
-      ),
-    );
-  }
 
   if (data.failedRuns.length > 0) {
     blocks.push(
       section(
-        `*:red_circle: Nieudane CI na main (${data.failedRuns.length})*\n` +
+        `*:red_circle: Blokuje wszystkich (${data.failedRuns.length})*\n` +
           bulletList(
             data.failedRuns.map(
               (run) =>
@@ -290,33 +352,68 @@ export function buildBlocks(
     );
   }
 
-  const notes = [];
+  let parked = 0;
 
-  if (data.openedIssues.length > 0) {
-    notes.push(`• Nowe issues: ${data.openedIssues.length}`);
-  }
+  for (const [title, items] of [
+    [":raised_back_of_hand: Czeka na autora", data.blockedOnAuthor],
+    [":eyes: Nikt nie wziął", data.unclaimed],
+    [":rocket: Jeden klik do merge", data.readyToMerge],
+  ]) {
+    const result = queueSection(title, items, now, weekly);
 
-  if (data.closedIssues.length > 0) {
-    notes.push(`• Zamknięte issues: ${data.closedIssues.length}`);
-  }
+    parked += result.parked;
 
-  for (const release of data.releases) {
-    notes.push(`• Release: ${link(release.html_url, release.tag_name)}`);
-  }
-
-  if (notes.length > 0) {
-    blocks.push(section(`*:memo: Issues i release*\n${bulletList(notes)}`));
+    if (result.block) {
+      blocks.push(result.block);
+    }
   }
 
   if (blocks.length === 0) {
-    blocks.push(section("_Brak ruchu w repozytorium od ostatniego daily._"));
+    blocks.push(section("_Nic nie czeka na ruch._"));
   }
 
-  if (comment) {
-    heading.push(section(`_${escapeMrkdwn(comment)}_`));
+  return [...heading, ...blocks, backgroundBlock(data, { parked, weekly })];
+}
+
+/**
+ * Merged pull requests, issue counts, and releases generate no decision, so they
+ * belong in one small line rather than in a list of their own.
+ */
+function backgroundBlock(data, { parked, weekly }) {
+  const notes = [];
+
+  if (data.merged.length > 0) {
+    notes.push(
+      `${data.merged.length} ${weekly ? "PR-ów w tygodniu" : "PR-ów zmergowanych"}`,
+    );
   }
 
-  return [...heading, ...blocks];
+  for (const release of data.releases.slice(0, MAX_RELEASES_SHOWN)) {
+    notes.push(link(release.html_url, release.tag_name));
+  }
+
+  if (data.releases.length > MAX_RELEASES_SHOWN) {
+    notes.push(`+${data.releases.length - MAX_RELEASES_SHOWN} release`);
+  }
+
+  if (data.openedIssues.length > 0) {
+    notes.push(`nowe issues: ${data.openedIssues.length}`);
+  }
+
+  if (data.closedIssues.length > 0) {
+    notes.push(`zamknięte issues: ${data.closedIssues.length}`);
+  }
+
+  if (parked > 0) {
+    notes.push(`odstawione: ${parked} (lista w pon.)`);
+  }
+
+  return {
+    type: "context",
+    elements: [
+      { type: "mrkdwn", text: notes.join(" · ") || "bez zmian w tle" },
+    ],
+  };
 }
 
 /**
@@ -333,18 +430,51 @@ function described(item) {
   };
 }
 
-export function summarizeForPrompt(data, { weekly } = {}) {
-  const titles = (items) => items.slice(0, 10).map((item) => item.title);
+/**
+ * Parked pull requests are missing from the message on a weekday. The comment is
+ * the one place that can still nudge about them, so it needs to know they exist.
+ */
+function parkedFor(data, now, weekly) {
+  if (weekly) {
+    return [];
+  }
+
+  return [data.blockedOnAuthor, data.unclaimed, data.readyToMerge]
+    .flat()
+    .filter((item) => ageBucket(item.created_at, now) === "parked")
+    .slice(0, 10)
+    .map((item) => ({
+      title: item.title,
+      author: item.user?.login ?? null,
+      ageDays: Math.floor(
+        (now.getTime() - new Date(item.created_at).getTime()) / DAY_MS,
+      ),
+    }));
+}
+
+export function summarizeForPrompt(data, { weekly, now = new Date() } = {}) {
+  const visible = (items) => splitParked(items, now, weekly).shown;
+  const queue = (items) =>
+    items.slice(0, 10).map((item) => ({
+      ...described(item),
+      author: item.user?.login ?? null,
+      ageDays: Math.floor(
+        (now.getTime() - new Date(item.created_at).getTime()) / DAY_MS,
+      ),
+      ...(item.reason ? { reason: item.reason } : {}),
+    }));
 
   return {
     window: weekly ? "lastWeek" : "sinceLastDaily",
+    redCiOnMain: data.failedRuns.slice(0, 10).map((run) => run.name),
+    blockedOnAuthor: queue(visible(data.blockedOnAuthor)),
+    unclaimed: queue(visible(data.unclaimed)),
+    parked: parkedFor(data, now, weekly),
+    readyToMerge: visible(data.readyToMerge)
+      .slice(0, 10)
+      .map((item) => ({ title: item.title, author: item.user?.login ?? null })),
+    mergedCount: data.merged.length,
     merged: data.merged.slice(0, 10).map(described),
-    awaitingReview: data.toReview.slice(0, 10).map((item) => ({
-      ...described(item),
-      createdAt: item.created_at,
-    })),
-    approved: titles(data.approved),
-    failedCi: data.failedRuns.slice(0, 10).map((run) => run.name),
     openedIssues: data.openedIssues.length,
     closedIssues: data.closedIssues.length,
     releases: data.releases.map((release) => release.tag_name),
@@ -371,7 +501,7 @@ async function requestComment(data, { weekly }) {
       "claude",
       [
         "--print",
-        JSON.stringify(summarizeForPrompt(data, { weekly })),
+        JSON.stringify(summarizeForPrompt(data, { weekly, now: new Date() })),
         "--system-prompt",
         COMMENT_SYSTEM_PROMPT,
         "--model",

--- a/.github/scripts/daily-summary.test.mjs
+++ b/.github/scripts/daily-summary.test.mjs
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  ageBucket,
   buildBlocks,
+  classifyOpenPullRequests,
   escapeMrkdwn,
   formatAge,
   readComment,
@@ -19,8 +21,9 @@ const CONTEXT = {
 
 const EMPTY = {
   merged: [],
-  toReview: [],
-  approved: [],
+  blockedOnAuthor: [],
+  unclaimed: [],
+  readyToMerge: [],
   failedRuns: [],
   openedIssues: [],
   closedIssues: [],
@@ -38,8 +41,14 @@ function pullRequest(overrides) {
   };
 }
 
+function daysAgo(days) {
+  return new Date(NOW.getTime() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
 function textOf(blocks) {
-  return blocks.map((block) => block.text?.text ?? "").join("\n");
+  return blocks
+    .map((block) => block.text?.text ?? block.elements?.[0]?.text ?? "")
+    .join("\n");
 }
 
 test("Monday recaps the whole previous week", () => {
@@ -50,7 +59,7 @@ test("Monday recaps the whole previous week", () => {
 });
 
 test("every other weekday reports since the last daily", () => {
-  const friday = resolveWindow(new Date("2026-08-28T09:45:00Z"));
+  const friday = resolveWindow(NOW);
 
   assert.equal(friday.lookbackHours, 24);
   assert.equal(friday.weekly, false);
@@ -61,20 +70,6 @@ test("an override changes the window but not the shape of the message", () => {
 
   assert.equal(monday.lookbackHours, 2);
   assert.equal(monday.weekly, true);
-  assert.equal(
-    resolveWindow(new Date("2026-08-28T09:45:00Z"), "junk").lookbackHours,
-    24,
-  );
-});
-
-test("Monday carries a different heading", () => {
-  const weekly = buildBlocks(EMPTY, { ...CONTEXT, weekly: true });
-
-  assert.equal(weekly[0].text.text, "Podsumowanie zeszłego tygodnia");
-  assert.equal(
-    buildBlocks(EMPTY, CONTEXT)[0].text.text,
-    "Podsumowanie GitHub przed daily",
-  );
 });
 
 test("mrkdwn control characters in a title cannot break a link", () => {
@@ -85,61 +80,73 @@ test("mrkdwn control characters in a title cannot break a link", () => {
 });
 
 test("age reads in hours below a day and in days above it", () => {
-  assert.equal(formatAge("2026-08-28T04:45:00Z", NOW), "5 godz.");
-  assert.equal(formatAge("2026-08-27T09:45:00Z", NOW), "1 dzień");
-  assert.equal(formatAge("2026-08-21T09:45:00Z", NOW), "7 dni");
+  assert.equal(formatAge(daysAgo(0.2), NOW), "4 godz.");
+  assert.equal(formatAge(daysAgo(1), NOW), "1 dzień");
+  assert.equal(formatAge(daysAgo(7), NOW), "7 dni");
 });
 
-test("a quiet repository still produces a message", () => {
-  const blocks = buildBlocks(EMPTY, CONTEXT);
-
-  assert.equal(blocks.length, 3);
-  assert.match(textOf(blocks), /Brak ruchu/);
+test("age buckets follow the two thresholds", () => {
+  assert.equal(ageBucket(daysAgo(1), NOW), "fresh");
+  assert.equal(ageBucket(daysAgo(2), NOW), "warn");
+  assert.equal(ageBucket(daysAgo(4), NOW), "warn");
+  assert.equal(ageBucket(daysAgo(5), NOW), "parked");
 });
 
-test("a pull request older than two days is marked stale", () => {
+test("a red build puts the ball with the author, even when approved", () => {
+  const failing = pullRequest({ number: 10 });
+  const result = classifyOpenPullRequests({
+    unreviewed: [],
+    changesRequested: [],
+    failingChecks: [failing],
+    approved: [failing],
+  });
+
+  assert.equal(result.blockedOnAuthor.length, 1);
+  assert.equal(result.blockedOnAuthor[0].reason, "CI czerwone");
+  assert.deepEqual(result.readyToMerge, []);
+});
+
+test("a requested change puts the ball with the author", () => {
+  const result = classifyOpenPullRequests({
+    unreviewed: [pullRequest({ number: 11 })],
+    changesRequested: [pullRequest({ number: 11 })],
+    failingChecks: [],
+    approved: [],
+  });
+
+  assert.equal(result.blockedOnAuthor[0].reason, "zmiany do poprawy");
+  assert.deepEqual(result.unclaimed, []);
+});
+
+test("a red build outranks a requested change as the reason", () => {
+  const both = pullRequest({ number: 12 });
+  const result = classifyOpenPullRequests({
+    unreviewed: [],
+    changesRequested: [both],
+    failingChecks: [both],
+    approved: [],
+  });
+
+  assert.equal(result.blockedOnAuthor.length, 1);
+  assert.equal(result.blockedOnAuthor[0].reason, "CI czerwone");
+});
+
+test("an untouched pull request stays unclaimed and a clean approval stays ready", () => {
+  const result = classifyOpenPullRequests({
+    unreviewed: [pullRequest({ number: 13 })],
+    changesRequested: [],
+    failingChecks: [],
+    approved: [pullRequest({ number: 14 })],
+  });
+
+  assert.equal(result.unclaimed[0].number, 13);
+  assert.equal(result.readyToMerge[0].number, 14);
+});
+
+test("red CI on main leads the message", () => {
   const blocks = buildBlocks(
     {
       ...EMPTY,
-      toReview: [pullRequest({ created_at: "2026-08-20T09:45:00Z" })],
-    },
-    CONTEXT,
-  );
-
-  assert.match(textOf(blocks), /:hourglass:/);
-});
-
-test("a fresh pull request is not marked stale", () => {
-  const blocks = buildBlocks({ ...EMPTY, toReview: [pullRequest()] }, CONTEXT);
-
-  assert.doesNotMatch(textOf(blocks), /:hourglass:/);
-});
-
-test("a merged pull request carries no age marker", () => {
-  const blocks = buildBlocks(
-    { ...EMPTY, merged: [pullRequest({ created_at: "2026-06-01T09:45:00Z" })] },
-    CONTEXT,
-  );
-
-  assert.doesNotMatch(textOf(blocks), /:hourglass:/);
-});
-
-test("a long list is truncated and reports the remainder", () => {
-  const many = Array.from({ length: 14 }, (_, index) =>
-    pullRequest({ number: index + 1 }),
-  );
-  const text = textOf(buildBlocks({ ...EMPTY, merged: many }, CONTEXT));
-
-  assert.match(text, /Zmergowane do main \(14\)/);
-  assert.match(text, /…i 4 więcej/);
-});
-
-test("every section renders when data is present", () => {
-  const blocks = buildBlocks(
-    {
-      merged: [pullRequest({ number: 10 })],
-      toReview: [pullRequest({ number: 11 })],
-      approved: [pullRequest({ number: 12 })],
       failedRuns: [
         {
           name: "Linters & Tests",
@@ -148,61 +155,109 @@ test("every section renders when data is present", () => {
           head_commit: { message: "fix: a thing\n\nbody" },
         },
       ],
-      openedIssues: [{}],
-      closedIssues: [{}, {}],
+      readyToMerge: [pullRequest()],
+    },
+    CONTEXT,
+  );
+
+  assert.match(blocks[2].text.text, /Blokuje wszystkich/);
+  assert.match(blocks[3].text.text, /Jeden klik do merge/);
+});
+
+test("the sections follow the owner of the next move", () => {
+  const text = textOf(
+    buildBlocks(
+      {
+        ...EMPTY,
+        blockedOnAuthor: [pullRequest({ number: 20, reason: "CI czerwone" })],
+        unclaimed: [pullRequest({ number: 21 })],
+        readyToMerge: [pullRequest({ number: 22 })],
+      },
+      CONTEXT,
+    ),
+  );
+
+  assert.match(text, /Czeka na autora \(1\)/);
+  assert.match(text, /Nikt nie wziął \(1\)/);
+  assert.match(text, /Jeden klik do merge \(1\)/);
+  assert.match(text, /#20 feat: something.*CI czerwone/);
+});
+
+test("a parked pull request is counted on a weekday, not listed", () => {
+  const blocks = buildBlocks(
+    { ...EMPTY, unclaimed: [pullRequest({ created_at: daysAgo(41) })] },
+    CONTEXT,
+  );
+  const text = textOf(blocks);
+
+  assert.doesNotMatch(text, /Nikt nie wziął/);
+  assert.match(text, /odstawione: 1/);
+});
+
+test("Monday lists the parked pull requests instead of counting them", () => {
+  const text = textOf(
+    buildBlocks(
+      { ...EMPTY, unclaimed: [pullRequest({ created_at: daysAgo(41) })] },
+      { ...CONTEXT, weekly: true },
+    ),
+  );
+
+  assert.match(text, /Nikt nie wziął \(1\)/);
+  assert.doesNotMatch(text, /odstawione/);
+});
+
+test("a pull request past the warn threshold carries a marker", () => {
+  const text = textOf(
+    buildBlocks(
+      { ...EMPTY, unclaimed: [pullRequest({ created_at: daysAgo(3) })] },
+      CONTEXT,
+    ),
+  );
+
+  assert.match(text, /:small_red_triangle:/);
+  assert.doesNotMatch(
+    textOf(buildBlocks({ ...EMPTY, unclaimed: [pullRequest()] }, CONTEXT)),
+    /:small_red_triangle:/,
+  );
+});
+
+test("merged pull requests reach the background line, not a section", () => {
+  const blocks = buildBlocks(
+    {
+      ...EMPTY,
+      merged: [pullRequest(), pullRequest()],
       releases: [
         {
           tag_name: "v1.0.0",
-          html_url:
-            "https://github.com/mirumee/nimara-ecommerce/releases/tag/v1.0.0",
+          html_url: "https://github.com/x/y/releases/tag/v1.0.0",
         },
       ],
     },
     CONTEXT,
   );
-  const text = textOf(blocks);
+  const background = blocks.at(-1);
 
-  assert.equal(blocks.length, 7);
-  assert.match(text, /Linters &amp; Tests/);
-  assert.doesNotMatch(text, /body/);
-  assert.match(text, /Nowe issues: 1/);
-  assert.match(text, /Zamknięte issues: 2/);
-  assert.match(text, /v1\.0\.0/);
+  assert.equal(background.type, "context");
+  assert.match(background.elements[0].text, /2 PR-ów zmergowanych/);
+  assert.match(background.elements[0].text, /v1\.0\.0/);
+  assert.doesNotMatch(textOf(blocks.slice(0, -1)), /Zmergowane/);
 });
 
-test("a section stays inside the Slack text limit", () => {
-  const many = Array.from({ length: 200 }, (_, index) =>
-    pullRequest({ number: index, title: "x".repeat(300) }),
-  );
+test("a quiet repository says so and still carries the background line", () => {
+  const blocks = buildBlocks(EMPTY, CONTEXT);
 
-  for (const block of buildBlocks({ ...EMPTY, merged: many }, CONTEXT)) {
-    assert.ok((block.text?.text ?? "").length <= 3000);
-  }
+  assert.match(textOf(blocks), /Nic nie czeka na ruch/);
+  assert.equal(blocks.at(-1).elements[0].text, "bez zmian w tle");
 });
 
 test("a Claude comment sits above the sections", () => {
   const blocks = buildBlocks(
-    { ...EMPTY, merged: [pullRequest()] },
-    {
-      ...CONTEXT,
-      comment: "Dwa PR-y czekają na review dłużej niż dwa tygodnie.",
-    },
+    { ...EMPTY, readyToMerge: [pullRequest()] },
+    { ...CONTEXT, comment: "Dwa PR-y czekają na klik." },
   );
 
   assert.match(blocks[2].text.text, /Dwa PR-y czekają/);
-  assert.match(blocks[3].text.text, /Zmergowane do main/);
-});
-
-test("a comment does not suppress the quiet message", () => {
-  const blocks = buildBlocks(EMPTY, { ...CONTEXT, comment: "Spokojny dzień." });
-  const text = textOf(blocks);
-
-  assert.match(text, /Spokojny dzień/);
-  assert.match(text, /Brak ruchu/);
-});
-
-test("no comment leaves the block layout unchanged", () => {
-  assert.equal(buildBlocks(EMPTY, CONTEXT).length, 3);
+  assert.match(blocks[3].text.text, /Jeden klik do merge/);
 });
 
 test("a comment with mrkdwn control characters cannot break the message", () => {
@@ -214,62 +269,74 @@ test("a comment with mrkdwn control characters cannot break the message", () => 
   assert.match(textOf(blocks), /Uwaga na &lt;b&gt; &amp; spółkę/);
 });
 
-test("the prompt payload carries titles and counts, not whole API objects", () => {
-  const payload = summarizeForPrompt({
-    ...EMPTY,
-    merged: [pullRequest({ title: "feat: a" })],
-    toReview: [
-      pullRequest({ title: "fix: b", created_at: "2026-08-01T00:00:00Z" }),
-    ],
-    openedIssues: [{}, {}],
-    releases: [{ tag_name: "v1.2.3" }],
-  });
+test("a long list is truncated and reports the remainder", () => {
+  const many = Array.from({ length: 14 }, (_, index) =>
+    pullRequest({ number: index + 1 }),
+  );
+  const text = textOf(buildBlocks({ ...EMPTY, unclaimed: many }, CONTEXT));
 
-  assert.deepEqual(payload.merged, [{ title: "feat: a", description: null }]);
-  assert.deepEqual(payload.awaitingReview, [
-    { title: "fix: b", description: null, createdAt: "2026-08-01T00:00:00Z" },
+  assert.match(text, /Nikt nie wziął \(14\)/);
+  assert.match(text, /…i 4 więcej/);
+});
+
+test("a section stays inside the Slack text limit", () => {
+  const many = Array.from({ length: 200 }, (_, index) =>
+    pullRequest({ number: index, title: "x".repeat(300) }),
+  );
+
+  for (const block of buildBlocks({ ...EMPTY, unclaimed: many }, CONTEXT)) {
+    assert.ok((block.text?.text ?? "").length <= 3000);
+  }
+});
+
+test("the prompt payload mirrors the sections", () => {
+  const payload = summarizeForPrompt(
+    {
+      ...EMPTY,
+      failedRuns: [{ name: "Linters & Tests" }],
+      blockedOnAuthor: [
+        pullRequest({
+          number: 30,
+          reason: "CI czerwone",
+          created_at: daysAgo(3),
+        }),
+      ],
+      unclaimed: [
+        pullRequest({ number: 31, body: "Zmienia liczenie rabatu." }),
+      ],
+      readyToMerge: [pullRequest({ number: 32 })],
+      merged: [pullRequest({ number: 33 })],
+      releases: [{ tag_name: "v1.2.3" }],
+    },
+    { now: NOW },
+  );
+
+  assert.deepEqual(payload.redCiOnMain, ["Linters & Tests"]);
+  assert.equal(payload.blockedOnAuthor[0].reason, "CI czerwone");
+  assert.equal(payload.blockedOnAuthor[0].ageDays, 3);
+  assert.equal(payload.blockedOnAuthor[0].author, "someone");
+  assert.equal(payload.unclaimed[0].description, "Zmienia liczenie rabatu.");
+  assert.deepEqual(payload.readyToMerge, [
+    { title: "feat: something", author: "someone" },
   ]);
-  assert.equal(payload.openedIssues, 2);
+  assert.equal(payload.mergedCount, 1);
   assert.deepEqual(payload.releases, ["v1.2.3"]);
 });
 
-test("the prompt payload caps each list at ten entries", () => {
-  const many = Array.from({ length: 40 }, (_, index) =>
-    pullRequest({ number: index }),
-  );
-  const payload = summarizeForPrompt({
-    ...EMPTY,
-    merged: many,
-    toReview: many,
-  });
-
-  assert.equal(payload.merged.length, 10);
-  assert.equal(payload.awaitingReview.length, 10);
-});
-
-test("the prompt payload carries the pull request description", () => {
-  const payload = summarizeForPrompt({
-    ...EMPTY,
-    merged: [pullRequest({ body: "Zmienia sposób liczenia rabatu." })],
-  });
-
-  assert.equal(
-    payload.merged[0].description,
-    "Zmienia sposób liczenia rabatu.",
-  );
-});
-
 test("a long description is truncated and an empty one becomes null", () => {
-  const payload = summarizeForPrompt({
-    ...EMPTY,
-    merged: [
-      pullRequest({ body: "x".repeat(2000) }),
-      pullRequest({ body: "   " }),
-    ],
-  });
+  const payload = summarizeForPrompt(
+    {
+      ...EMPTY,
+      unclaimed: [
+        pullRequest({ body: "x".repeat(2000) }),
+        pullRequest({ body: "   " }),
+      ],
+    },
+    { now: NOW },
+  );
 
-  assert.equal(payload.merged[0].description.length, 600);
-  assert.equal(payload.merged[1].description, null);
+  assert.equal(payload.unclaimed[0].description.length, 600);
+  assert.equal(payload.unclaimed[1].description, null);
 });
 
 test("the prompt payload names the window", () => {
@@ -282,11 +349,11 @@ test("a successful envelope yields the comment", () => {
     JSON.stringify({
       subtype: "success",
       is_error: false,
-      result: "  Spokojny tydzień.  ",
+      result: "  Spokojnie.  ",
     }),
   );
 
-  assert.equal(comment, "Spokojny tydzień.");
+  assert.equal(comment, "Spokojnie.");
 });
 
 test("an envelope that reports an error yields no comment", () => {
@@ -309,4 +376,44 @@ test("a successful envelope with an empty result yields no comment", () => {
 
 test("output that is not JSON yields no comment", () => {
   assert.equal(readComment("command not found: claude"), null);
+});
+
+test("the background line caps the release list", () => {
+  const releases = Array.from({ length: 5 }, (_, index) => ({
+    tag_name: `v1.0.${index}`,
+    html_url: `https://github.com/x/y/releases/tag/v1.0.${index}`,
+  }));
+  const background = buildBlocks({ ...EMPTY, releases }, CONTEXT).at(-1);
+
+  assert.match(background.elements[0].text, /v1\.0\.0/);
+  assert.match(background.elements[0].text, /v1\.0\.1/);
+  assert.doesNotMatch(background.elements[0].text, /v1\.0\.2/);
+  assert.match(background.elements[0].text, /\+3 release/);
+});
+
+test("the prompt payload hides parked entries from the queues but names them apart", () => {
+  const payload = summarizeForPrompt(
+    {
+      ...EMPTY,
+      unclaimed: [
+        pullRequest({ number: 40, created_at: daysAgo(1) }),
+        pullRequest({ number: 41, created_at: daysAgo(41) }),
+      ],
+    },
+    { now: NOW },
+  );
+
+  assert.equal(payload.unclaimed.length, 1);
+  assert.equal(payload.parked.length, 1);
+  assert.equal(payload.parked[0].ageDays, 41);
+});
+
+test("Monday keeps the parked entries in the queues and sends none apart", () => {
+  const payload = summarizeForPrompt(
+    { ...EMPTY, unclaimed: [pullRequest({ created_at: daysAgo(41) })] },
+    { now: NOW, weekly: true },
+  );
+
+  assert.equal(payload.unclaimed.length, 1);
+  assert.deepEqual(payload.parked, []);
 });

--- a/llm-wiki/operations/OPS-0009 Daily GitHub Summary Bot.md
+++ b/llm-wiki/operations/OPS-0009 Daily GitHub Summary Bot.md
@@ -28,9 +28,17 @@ The bot posts one message at 09:45 Europe/Warsaw, Monday to Friday, 15 minutes b
 daily meeting. It does not run at the weekend.
 
 Monday opens the week with a recap of the whole previous week and a heading that says so. Every
-other weekday reports the activity since the previous daily. The message lists pull requests merged since the previous daily, open pull
-requests waiting for review, failed `Linters & Tests` runs on `main`, and issue and release
-activity.
+other weekday reports the activity since the previous daily.
+
+The message is ordered by who owns the next move on each open pull request:
+
+1. Red `Linters & Tests` runs on `main`, which block everyone.
+2. Pull requests with a failing build or a requested change, which wait on their author.
+3. Pull requests with no review, which nobody has taken.
+4. Approved pull requests with a green build, which wait on a merge.
+
+Merged pull requests, issue counts, and releases sit in one small line at the bottom. They
+generate no decision, so they do not earn a section of their own.
 
 # Preconditions
 
@@ -107,10 +115,31 @@ plan's limits rather than in dollars.
 usable only with an API key. To drop the comment and keep the sections, delete the credential secret. No code change is
 needed.
 
+## Tune the age thresholds
+
+`WARN_PR_DAYS` is 2 and `PARKED_PR_DAYS` is 5 in `.github/scripts/daily-summary.mjs`.
+
+The median pull request in this repository merges the day it opens. Two days is therefore
+already an outlier and earns the `:small_red_triangle:` marker. Five days means parked rather
+than in flight.
+
+A parked pull request is counted on a weekday and listed on Monday. Without that split the same
+entries appear every morning and the channel stops reading the message. The Claude comment still
+receives them separately and may name at most one, so a parked pull request that truly needs a
+decision can still surface.
+
+Re-measure before you change either number:
+
+```bash
+gh api "search/issues?q=repo:mirumee/nimara-ecommerce+is:pr+is:merged&sort=updated&order=desc&per_page=40" \
+  --jq '[.items[]|select(.user.type!="Bot")|((.closed_at|fromdate)-(.created_at|fromdate))/86400|floor]|sort|@json'
+```
+
 ## Change the summary content
 
 1. Open `.github/scripts/daily-summary.mjs`.
-2. `collect` holds every GitHub query. `buildBlocks` holds every Slack section.
+2. `collect` holds every GitHub query and `classifyOpenPullRequests` decides who owns the next
+   move on each open pull request. `buildBlocks` holds every Slack section.
    `COMMENT_SYSTEM_PROMPT` holds the instructions for the Claude comment, and
    `summarizeForPrompt` holds what Claude receives.
 3. The script has no dependencies. It runs on the Node version in `.nvmrc`.


### PR DESCRIPTION
The message listed merged pull requests first and the review queue as one pile. Neither shape
produces a decision at the meeting: a merged pull request is history, and a pile does not say
who acts.

## Before and after

Before, on live data, the message ran to four sections and roughly half a screen. After, the
same moment renders as five blocks:

```
Podsumowanie GitHub przed daily
mirumee/nimara-ecommerce · ostatnie 24 godz.

Dwa PR-y Piotra czekają tylko na merge — warto ustalić na daily, kto je
klika i czy wchodzą razem. Poza tym kolejka jest czysta.

🚀 Jeden klik do merge (2)
• #798 feat: Handle http | dashboard service type — piotrgrundas · 21 godz.
• #797 refactor: Move the dashboard plumbing into the library — piotrgrundas · 22 godz.

8 PR-ów zmergowanych · v2.15.0 · v2.14.1 · +3 release · odstawione: 1 (lista w pon.)
```

## One owner per pull request

`classifyOpenPullRequests` puts every open, non-draft pull request in exactly one section:

| Signal | Owner of the next move | Section |
| --- | --- | --- |
| `status:failure` or `review:changes_requested` | the author | ✋ Czeka na autora |
| `review:none` | nobody has taken it | 👀 Nikt nie wziął |
| `review:approved`, build green | whoever merges | 🚀 Jeden klik do merge |

A failing build or a requested change outranks an approval. Nobody should merge a pull request
whose checks are red, so an approved-and-failing pull request belongs with its author.

Red CI on `main` leads the message. It blocks everyone, and it used to sit fourth.

`requested_reviewers` is empty on every open pull request in this repository, so the sections
name authors rather than suggesting reviewers.

## Merged pull requests leave the body

They move to one context line with the issue counts and releases. 29 of the last 36 pull
requests merged the day they opened, so yesterday's merges are things the team already watched
happen. The release list is capped at two with a `+N` suffix.

## Parked pull requests stop repeating

A pull request older than 5 days counts as parked. A weekday message reports the count; Monday
lists them.

This is the change that keeps the message readable. `#713` has been open 41 days and `#760` for
18. Printing them every morning trains the channel to scroll past the whole message. The Claude
comment still receives the parked entries separately and may name at most one, so a parked pull
request that genuinely needs a decision can still surface.

## The thresholds come from the repository

`WARN_PR_DAYS` is 2 and `PARKED_PR_DAYS` is 5. Measured over the last 36 non-bot merges:

```
[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,2,2,2,4,6,7]
```

The median merges the day it opens. Two days is already around the 85th percentile, which is
why the marker fires there rather than later. Five days means parked rather than in flight. The
runbook carries the command to re-measure before either number is changed.

## Testing

`node --test ".github/scripts/*.test.mjs"` passes 31 tests. New coverage: the three-way
ownership split and its precedence, the two age buckets, red CI leading the message, a parked
entry counted on a weekday and listed on Monday, merged pull requests reaching the background
line rather than a section, the release cap, and the parked entries reaching the prompt payload
while staying out of its queues.

Verified end to end against live GitHub data with a real Claude Code session.

`pnpm wiki:lint` reports zero violations across 97 files.

## Rollback

Revert this pull request. The change is presentation only: no new secret, no new dependency, and
the same GitHub API surface plus three read-only search queries.

# Pull Request Checklist

- [x] Target `main` from a short-lived change branch and use a Conventional Commit PR title.
- [x] Test the changes locally to ensure they work as expected.
- [x] Document the testing process and results in the pull request description.
- [ ] Verify all four Vercel project statuses: `nimara-docs`, `nimara-ecommerce`,
      `nimara-ecommerce-stripe`, and `nimara-marketplace`.
- [x] Include new tests for any new functionality or significant changes.
- [x] Ensure that tests cover edge cases and potential failure points.
- [x] Keep incomplete behavior disabled with a short-lived feature flag or branch-by-abstraction seam.
- [x] Document the impact of the changes on the system, including potential risks and benefits.
- [x] Provide a rollback plan in case the changes introduce critical issues.
- [x] Update documentation to reflect any changes in functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
