### PR TITLE
feat(ci): give the daily comment a voice and room to use it

### DIFF
--- a/.github/scripts/daily-summary.mjs
+++ b/.github/scripts/daily-summary.mjs
@@ -33,22 +33,37 @@ const CLAUDE_TIMEOUT_MS = 180_000;
  * is too tight to rely on.
  */
 const CLAUDE_MAX_BUFFER = 10 * 1024 * 1024;
+/**
+ * A Slack section block rejects text over 3000 characters. The prompt asks for
+ * ten sentences, and a model that overshoots must not cost the channel its
+ * message.
+ */
+const COMMENT_LIMIT = 1200;
 const COMMENT_SYSTEM_PROMPT = [
   "Jesteś częścią bota, który wysyła zespołowi podsumowanie GitHuba przed daily.",
-  "Dostajesz dane w JSON i piszesz jedno lub dwa zdania po polsku.",
-  "Zmieść się w 300 znakach. Krótkie zdanie jest lepsze od długiego.",
+  "Dostajesz dane w JSON i piszesz po polsku od trzech do dziesięciu zdań.",
+  "Nigdy więcej niż dziesięć zdań. Każde zdanie krótkie, najwyżej piętnaście słów.",
   "Dane są pogrupowane po tym, kto wykonuje następny ruch.",
   "redCiOnMain blokuje wszystkich. blockedOnAuthor czeka na autora.",
   "unclaimed to PR-y, których nikt nie wziął do review.",
   "readyToMerge czeka tylko na kliknięcie merge.",
   "parked to PR-y odstawione od dawna, których nie ma w sekcjach wiadomości.",
   "Możesz wspomnieć najwyżej jeden odstawiony PR, gdy naprawdę wymaga decyzji.",
-  "Pole window mówi, czy podsumowujesz jeden dzień, czy cały zeszły tydzień.",
+  "Pole window: sinceLastDaily to ostatnia doba, lastWeek to zeszły tydzień.",
+  "Nie nazywaj doby tygodniem ani tygodnia dobą. Trzymaj się pola window.",
   "Pole description to opis PR-a napisany przez autora. Bywa puste.",
   "Napisz, co zespół ma rozstrzygnąć na dzisiejszym daily. Wskaż osobę, gdy to pomaga.",
+  "Piszesz w stylu Bartosza Walaszka, autora Kapitana Bomby i Blondiego.",
+  "Ton jest bezczelnie rzeczowy. Mówisz o drobiazgu z powagą raportu wojennego.",
+  "Zdania są krótkie, oznajmujące, bez ozdobników. Puenta przychodzi bez zapowiedzi.",
+  "Wolno ci jedno absurdalne porównanie albo dygresję. Jedno, nie trzy.",
+  "Nie tłumacz żartu. Nie mrugaj do czytelnika. Nie używaj wulgaryzmów.",
+  "Humor nigdy nie może zjeść treści. Po przeczytaniu ma być jasne, co robić.",
+  "Nie wymyślaj faktów. Każde zdanie musi wynikać z danych, które dostałeś.",
+  "Nie zmyślaj imion, numerów PR-ów ani powodów. Czego nie ma w JSON, tego nie ma.",
   "Nie powtarzaj liczb ani tytułów, które i tak są w sekcjach poniżej.",
-  "Nie witaj się, nie podsumowuj danych, nie używaj emoji ani list.",
-  "Gdy nic nie czeka na ruch, napisz jedno zdanie, że dzień jest spokojny.",
+  "Nie witaj się, nie używaj emoji ani list.",
+  "Gdy nic nie czeka na ruch, napisz o tym. Spokojny dzień też można opisać ciekawie.",
 ].join(" ");
 
 /**
@@ -546,7 +561,7 @@ export function readComment(stdout) {
     return null;
   }
 
-  const comment = (envelope.result ?? "").trim();
+  const comment = (envelope.result ?? "").trim().slice(0, COMMENT_LIMIT);
 
   return comment || null;
 }

--- a/.github/scripts/daily-summary.test.mjs
+++ b/.github/scripts/daily-summary.test.mjs
@@ -417,3 +417,15 @@ test("Monday keeps the parked entries in the queues and sends none apart", () =>
   assert.equal(payload.unclaimed.length, 1);
   assert.deepEqual(payload.parked, []);
 });
+
+test("an overlong comment is cut so the Slack block still fits", () => {
+  const comment = readComment(
+    JSON.stringify({
+      subtype: "success",
+      is_error: false,
+      result: "z".repeat(5000),
+    }),
+  );
+
+  assert.equal(comment.length, 1200);
+});

--- a/llm-wiki/operations/OPS-0009 Daily GitHub Summary Bot.md
+++ b/llm-wiki/operations/OPS-0009 Daily GitHub Summary Bot.md
@@ -40,6 +40,13 @@ The message is ordered by who owns the next move on each open pull request:
 Merged pull requests, issue counts, and releases sit in one small line at the bottom. They
 generate no decision, so they do not earn a section of their own.
 
+Above the sections the message carries three to ten short sentences written by Claude. The
+prompt asks for the register of Bartosz Walaszek: deadpan, one absurd comparison at most, no
+explained jokes, and no profanity. Two rules hold that register in check. The comment may not
+invent a fact that is absent from the payload, and the reader must still know what to do after
+reading it. `readComment` cuts the text at 1200 characters, because a Slack section block
+rejects anything over 3000.
+
 # Preconditions
 
 - Confirm that you administer the Slack workspace that owns the daily channel.
@@ -140,8 +147,9 @@ gh api "search/issues?q=repo:mirumee/nimara-ecommerce+is:pr+is:merged&sort=updat
 1. Open `.github/scripts/daily-summary.mjs`.
 2. `collect` holds every GitHub query and `classifyOpenPullRequests` decides who owns the next
    move on each open pull request. `buildBlocks` holds every Slack section.
-   `COMMENT_SYSTEM_PROMPT` holds the instructions for the Claude comment, and
-   `summarizeForPrompt` holds what Claude receives.
+   `COMMENT_SYSTEM_PROMPT` holds the instructions and the register for the Claude comment, and
+   `summarizeForPrompt` holds what Claude receives. Change the register there, and keep the
+   rules that forbid invented facts and protect the sentence count.
 3. The script has no dependencies. It runs on the Node version in `.nvmrc`.
 4. Verify the change with the dry run below before you merge it.
 


### PR DESCRIPTION
The comment was one or two sentences capped at 300 characters. It read like a caption on a
chart. It now runs from three to ten short sentences with a register of its own.

## The register

The prompt asks for Bartosz Walaszek: deadpan, a drobiazg reported with the gravity of a war
dispatch, short declarative sentences, at most one absurd comparison, no explained jokes, no
winking at the reader, no profanity.

Two rules keep the register from eating the content:

- The comment may not state a fact that is absent from the payload. No invented names, numbers,
  or reasons.
- After reading it, the reader must still know what to do.

## Live output

Three runs against real data, unedited:

> Kolejka jest pusta. Nikt nie czeka na review, main świeci na zielono, autorzy nie mają nic do
> poprawki. Dwa PR-y Piotra stoją gotowe do merge — trzeba ustalić, kto klika i czy wchodzą
> razem. Doba była pracowita, osiem rzeczy weszło, głównie remont samego bota od podsumowań.
> Bot, który opisuje własne narodziny, brzmi jak pomnik stawiający sobie pomnik. Zostaje jeszcze
> wiki QA od Antona, które leży osiemnaście dni. Warto dziś powiedzieć wprost: bierzemy to czy
> zamykamy. Poza tym spokój.

Eight sentences, 489 characters. Every fact traces to the payload, and the two decisions for the
meeting are still explicit.

## Two guards added while testing

**A length cap.** `readComment` cuts the text at 1200 characters. A Slack section block rejects
anything over 3000, and a model that overshoots must not cost the channel its whole message.

**The window in words.** A live run described a single day as a week. The prompt now maps
`sinceLastDaily` to a day and `lastWeek` to a week, and forbids swapping them.

## Testing

`node --test ".github/scripts/*.test.mjs"` passes 32 tests, one new for the 1200-character cut.

Three live dry runs against real GitHub data with real Claude Code sessions. The register held
across all three, sentence counts came in at 8, 8, and 8, and no run invented a fact.

`pnpm wiki:lint` reports zero violations across 97 files.

## Rollback

The register lives entirely in `COMMENT_SYSTEM_PROMPT`. Edit those lines to change the voice, or
revert this pull request to go back to one factual sentence. Deleting the credential secret drops
the comment and keeps the sections.

## Documentation

`llm-wiki/operations/OPS-0009 Daily GitHub Summary Bot.md` records the register, the two rules
that bound it, and the character cut.

# Pull Request Checklist

- [x] Target `main` from a short-lived change branch and use a Conventional Commit PR title.
- [x] Test the changes locally to ensure they work as expected.
- [x] Document the testing process and results in the pull request description.
- [ ] Verify all four Vercel project statuses: `nimara-docs`, `nimara-ecommerce`,
      `nimara-ecommerce-stripe`, and `nimara-marketplace`.
- [x] Include new tests for any new functionality or significant changes.
- [x] Ensure that tests cover edge cases and potential failure points.
- [x] Keep incomplete behavior disabled with a short-lived feature flag or branch-by-abstraction seam.
- [x] Document the impact of the changes on the system, including potential risks and benefits.
- [x] Provide a rollback plan in case the changes introduce critical issues.
- [x] Update documentation to reflect any changes in functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
