### PR TITLE
chore: drop the dead .env.test loading and the unused dotenv dependency

### DIFF
--- a/apps/storefront/vitest.config.ts
+++ b/apps/storefront/vitest.config.ts
@@ -1,11 +1,5 @@
-import { config } from "dotenv";
-import { resolve } from "path";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";
-
-// Load .env.test from repo root (2 levels up from apps/storefront)
-const repoRoot = resolve(process.cwd(), "../..");
-const envTestPath = resolve(repoRoot, ".env.test");
 
 export default defineConfig({
   plugins: [tsconfigPaths()],
@@ -13,7 +7,6 @@ export default defineConfig({
     environment: "node",
     env: {
       ...process.env,
-      ...config({ path: envTestPath }).parsed,
       NODE_ENV: "test",
     },
     setupFiles: ["./src/foundation/tests/setup"],

--- a/apps/stripe/vitest.config.ts
+++ b/apps/stripe/vitest.config.ts
@@ -1,4 +1,3 @@
-import { config } from "dotenv";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";
 
@@ -8,7 +7,6 @@ export default defineConfig({
     environment: "node",
     env: {
       ...process.env,
-      ...config({ path: ".env.test", quiet: true }).parsed,
       NODE_ENV: "test",
     },
     setupFiles: ["./src/lib/test/setup"],

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -33,7 +33,6 @@
     "@types/react-dom": "^19.2.3",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
-    "dotenv": "17.4.1",
     "eslint": "^8.57.0",
     "typescript": "^5.9.2",
     "vite-tsconfig-paths": "6.1.1",

--- a/packages/foundation/vitest.config.ts
+++ b/packages/foundation/vitest.config.ts
@@ -1,11 +1,5 @@
-import { config } from "dotenv";
-import { resolve } from "path";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";
-
-// Load .env.test from repo root (2 levels up from packages/foundation)
-const repoRoot = resolve(process.cwd(), "../..");
-const envTestPath = resolve(repoRoot, ".env.test");
 
 // eslint-disable-next-line import/no-default-export
 export default defineConfig({
@@ -14,7 +8,6 @@ export default defineConfig({
     environment: "node",
     env: {
       ...process.env,
-      ...config({ path: envTestPath }).parsed,
       NODE_ENV: "test",
     },
   },

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -22,7 +22,6 @@
     "@types/react": "^19.2.14",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
-    "dotenv": "17.4.1",
     "eslint": "^8.57.0",
     "next": "catalog:",
     "typescript": "^5.9.2",

--- a/packages/i18n/vitest.config.ts
+++ b/packages/i18n/vitest.config.ts
@@ -1,11 +1,5 @@
-import { config } from "dotenv";
-import { resolve } from "path";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";
-
-// Load .env.test from repo root (2 levels up from packages/i18n)
-const repoRoot = resolve(process.cwd(), "../..");
-const envTestPath = resolve(repoRoot, ".env.test");
 
 // eslint-disable-next-line import/no-default-export
 export default defineConfig({
@@ -14,7 +8,6 @@ export default defineConfig({
     environment: "node",
     env: {
       ...process.env,
-      ...config({ path: envTestPath }).parsed,
       NODE_ENV: "test",
     },
     passWithNoTests: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -904,9 +904,6 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^6.21.0
         version: 6.21.0(eslint@8.57.1)(typescript@5.9.3)
-      dotenv:
-        specifier: 17.4.1
-        version: 17.4.1
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -950,9 +947,6 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^6.21.0
         version: 6.21.0(eslint@8.57.1)(typescript@5.9.3)
-      dotenv:
-        specifier: 17.4.1
-        version: 17.4.1
       eslint:
         specifier: ^8.57.0
         version: 8.57.1


### PR DESCRIPTION
I want to merge this change because our Vitest configs tried to load a settings file (`.env.test`) that does not exist in the repository and never has — `.gitignore` excludes it and no workflow creates it. The code did nothing, but it looked like a working mechanism: someone could create that file locally, base a test on it, pass on their machine, and fail on CI with no visible cause. This removes the sham along with the `dotenv` dependency it left behind without a consumer.

## Scope

- `apps/storefront`, `apps/stripe`, `packages/foundation`, `packages/i18n` — dropped the `.env.test` loading from the Vitest configs
- `packages/foundation`, `packages/i18n` — dropped the unused `dotenv` from `devDependencies` (+ lockfile)

`NODE_ENV: "test"` stays on purpose. Vitest sets it only when it is not already set, so that line guards against running the suite in production mode.

Should a real need for test-time environment variables ever appear in the storefront, the right tool is `loadEnvConfig` from `@next/env` — Next ships that handling built in, `.env.test` included, with no new dependency.

## Testing

- `pnpm turbo test --force` — 6/6 tasks green (i18n 2, infrastructure 5, features 3, marketplace 6, storefront 5, stripe 24 files)
- ESLint on the changed packages, without `--fix` — no issues
- Prettier on the changed `package.json` files — correctly formatted
- `pnpm install` — no missing-dependency errors

# Pull Request Checklist

- [x] Target `main` from a short-lived change branch and use a Conventional Commit PR title.
- [x] Test the changes locally to ensure they work as expected.
- [x] Document the testing process and results in the pull request description. (Screen recording, screenshot etc)
- [x] Verify all four Vercel project statuses: `nimara-docs`, `nimara-ecommerce`, `nimara-ecommerce-stripe`, and `nimara-marketplace`.
- [x] Include new tests for any new functionality or significant changes. — not applicable, no new functionality
- [x] Ensure that tests cover edge cases and potential failure points. — not applicable, dead-code removal
- [x] Keep incomplete behavior disabled with a short-lived feature flag or branch-by-abstraction seam. — not applicable, the change is complete
- [x] Document the impact of the changes on the system, including potential risks and benefits. — above; risk: none, the removed code never executed
- [x] Provide a rollback plan in case the changes introduce critical issues. — `git revert`; the change does not touch application runtime
- [x] Update documentation to reflect any changes in functionality. — not applicable, `.env.test` was never documented anywhere
