### PR TITLE
chore(ci): bump the remaining actions to Node 24 and pin third-party

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -27,3 +27,20 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+
+  # Majors are allowed here on purpose. A major action bump is normally just a
+  # runner-runtime change, and blocking them is why these fell eight versions
+  # behind. Grouped into one weekly pull request.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
+    commit-message:
+      prefix: "chore(ci)"
+    target-branch: "main"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -62,7 +62,7 @@ jobs:
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: "Build and deploy the environment"
-        uses: amondnet/vercel-action@v25.2.0
+        uses: amondnet/vercel-action@v42.3.0
         with:
           alias-domains: ${{ env.ALIAS_DOMAINS }}
           scope: mirumee

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -50,7 +50,7 @@ jobs:
           node-version: "lts/krypton"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Install dependencies
         working-directory: apps/docs
@@ -61,7 +61,7 @@ jobs:
         run: pnpm build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: apps/docs/build
 
@@ -75,4 +75,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: "lts/krypton"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
 
@@ -42,7 +42,7 @@ jobs:
         run: pnpm build
 
       - name: Restore lychee cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: .lycheecache
           key: cache-lychee-${{ hashFiles('apps/docs/lychee.toml') }}-${{ github.run_id }}
@@ -77,7 +77,7 @@ jobs:
       # subsequent runs don't re-check every URL from scratch.
       - name: Save lychee cache
         if: always() && steps.lychee.outcome != 'skipped'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: .lycheecache
           key: cache-lychee-${{ hashFiles('apps/docs/lychee.toml') }}-${{ github.run_id }}
@@ -117,7 +117,7 @@ jobs:
 
       - name: Create or update broken-link issue
         if: failure()
-        uses: peter-evans/create-issue-from-file@v5
+        uses: peter-evans/create-issue-from-file@v6
         with:
           title: Docs link check failed
           issue-number: ${{ steps.find_issue.outputs.issue-number }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
 
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upload CodeceptJS output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: codeceptjs-output
           path: apps/automated-tests/output

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
 
@@ -46,7 +46,7 @@ jobs:
       - name: Get changed files (for PRs)
         id: changed-files
         if: github.event_name == 'pull_request'
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         with:
           files_yaml: |
             ts:
@@ -55,7 +55,7 @@ jobs:
               - '**/*.tsx'
 
       - name: Restore ESLint cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: eslint-cache
         with:
           path: .eslintcache # Path to the ESLint cache file/directory

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
 


### PR DESCRIPTION
SHAs
