### PR TITLE
Promote the no-comment rule to the global rules

### DIFF
--- a/.claude/rules/comments.md
+++ b/.claude/rules/comments.md
@@ -1,8 +1,7 @@
 # Comments
 
-- Do not write comments in code. This applies to new code and to code that you edit.
 - If a fragment needs an explanation, rename the symbol or extract a function.
 - Keep comments that already exist in the file. Do not delete them and do not extend them.
-- Exceptions: a license header, a pragma that the toolchain reads
+- Exceptions to the no-comment rule: a license header, a pragma that the toolchain reads
   (`@ts-expect-error`, `eslint-disable`, `biome-ignore`), and a JSDoc block that the
   public API of a package must publish.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Nimara is a monorepo for composable commerce. It is an open-source, composable c
   Required checks are `Linters & Tests`, `Vercel – nimara-docs`,
   `Vercel – nimara-ecommerce`, `Vercel – nimara-ecommerce-stripe`, and
   `Vercel – nimara-marketplace`.
+- Do not write comments in code. This applies to new code and to code that you edit.
 - Split longer work into releasable slices. Keep incomplete behavior behind a short-lived,
   default-off feature flag or branch-by-abstraction seam, test meaningful states, and remove the flag after rollout.
 - Never add or remove a dependency without explicit user approval.


### PR DESCRIPTION
I want to merge this change because the no-comment rule was only enforced conditionally.

Follow-up to #802. That PR put the rule in `.claude/rules/comments.md`, but files in
`.claude/rules/` load on demand — in a live session only `comments.md` and `editing.md`
reached the context while `architecture.md`, `testing.md`, and `generated-code.md` did not.
A rule that may not be loaded is a rule the agent may not follow. `CLAUDE.md` is always in
context, so the prohibition now lives there and applies unconditionally.

## What changed

- `CLAUDE.md` — the prohibition joins the global rules: *Do not write comments in code. This
  applies to new code and to code that you edit.*
- `.claude/rules/comments.md` — keeps what supports the rule rather than restating it: the
  alternative (rename the symbol or extract a function), the guard against deleting existing
  comments, and the exception list. The exceptions bullet now names the rule it excepts, so
  the file reads coherently when it loads without `CLAUDE.md`.

Net effect is one line moved plus a three-word anchor. No duplication between the two files.

## Impact and risks

Instructions only — no application code, no build, no runtime behavior. The agent-visible
change is that the prohibition is unconditional and the guard against a comment purge in
edited files stays paired with it.

Risk is low and one-sided: if `CLAUDE.md` grows and this line loses salience, we are back to
today's behavior, not worse. Rollback is `git revert` of a single commit.

## Testing

Verified by inspection of the loaded context: `CLAUDE.md:24` carries the prohibition and
`.claude/rules/comments.md` carries the alternative, the guard, and the anchored exceptions.
Nothing here is covered by unit or E2E tests, and no Vercel project is affected — the four
project statuses should be unchanged from `main`.

# Pull Request Checklist

- [x] Target `main` from a short-lived change branch and use a Conventional Commit PR title.
- [x] Test the changes locally to ensure they work as expected.
- [x] Document the testing process and results in the pull request description.
- [ ] Verify all four Vercel project statuses: `nimara-docs`, `nimara-ecommerce`,
      `nimara-ecommerce-stripe`, and `nimara-marketplace`.
- [x] Include new tests for any new functionality or significant changes. — n/a, agent
      instructions carry no test surface.
- [x] Ensure that tests cover edge cases and potential failure points. — n/a, as above.
- [x] Keep incomplete behavior disabled with a short-lived feature flag or seam. — n/a, the
      change is complete in one commit.
- [x] Document the impact of the changes on the system, including potential risks and benefits.
- [x] Provide a rollback plan in case the changes introduce critical issues.
- [x] Update documentation to reflect any changes in functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
