### PR TITLE
feat: Rework app generator prompts and add blank (non-Saleor) integration

### DIFF
--- a/apps/stripe/src/services/handler/config.ts
+++ b/apps/stripe/src/services/handler/config.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { baseConfigSchema } from "@nimara/lib/config/schema";
+import { saleorConfigSchema } from "@nimara/lib/config/schema";
 import { prepareConfig } from "@nimara/lib/zod/util";
 
 import packageJson from "../../../package.json";
@@ -16,7 +16,7 @@ const configSchema = z
       .default("nimara-config")
       .describe("Config provider key."),
   })
-  .and(baseConfigSchema(packageJson));
+  .and(saleorConfigSchema(packageJson));
 
 const parsed = prepareConfig({
   name: "handler",

--- a/packages/lib/CLAUDE.md
+++ b/packages/lib/CLAUDE.md
@@ -1,8 +1,13 @@
 # Lib
 
-This package owns the shared runtime for Hono-based Saleor apps in `apps/*`: the HTTP
-error hierarchy, response envelope, middleware, env/config parsing, the Saleor app kit
-(manifest, register, webhook registry), and the Dashboard UI shell. The build
+This package owns the shared Hono app runtime used by every generated app in
+`apps/*`: the HTTP error hierarchy, response envelope, middleware, and
+env/config parsing. Saleor-specific pieces — the Saleor app kit (manifest,
+register, webhook registry), the Dashboard UI shell, and the
+`saleor-token`/`saleor-webhook-validation`/`allowed-domains` middleware — live
+under `saleor/**`, `hono/saleor/**`,
+`hono/middleware/{saleor-token,saleor-webhook-validation,allowed-domains}.ts`,
+and `client/**`. Code outside those paths must not import from them. The build
 machinery is `@nimara/tooling`.
 
 - Everything here must stay app-agnostic. A name, string, or schema field that only one

--- a/packages/lib/src/config/schema.test.ts
+++ b/packages/lib/src/config/schema.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
-import { baseConfigSchema } from "./schema";
+import { coreConfigSchema, saleorConfigSchema } from "./schema";
 
 const PKG = {
   author: "Nimara",
@@ -11,10 +11,10 @@ const PKG = {
 };
 
 const parse = (env: Record<string, unknown>) =>
-  baseConfigSchema(PKG).parse({ ENVIRONMENT: "test", ...env });
+  saleorConfigSchema(PKG).parse({ ENVIRONMENT: "test", ...env });
 
 describe("schema", () => {
-  describe("baseConfigSchema", () => {
+  describe("saleorConfigSchema", () => {
     it("derives the app's identity from its package.json", () => {
       // when
       const config = parse({});
@@ -91,7 +91,7 @@ describe("schema", () => {
         (key) => {
           // when / then blank is the only value it forgives.
           expect(
-            baseConfigSchema(PKG).safeParse({
+            saleorConfigSchema(PKG).safeParse({
               ENVIRONMENT: "test",
               [key]: "not a url",
             }).success,
@@ -113,7 +113,7 @@ describe("schema", () => {
         // given a value Sentry would swallow by disabling itself
 
         // when
-        const result = baseConfigSchema(PKG).safeParse({
+        const result = saleorConfigSchema(PKG).safeParse({
           ENVIRONMENT: "test",
           SENTRY_DSN: "o1.ingest.sentry.io/2",
         });
@@ -126,7 +126,7 @@ describe("schema", () => {
     describe("VITE_SALEOR_APP_TOKEN", () => {
       it("refuses the development token in production", () => {
         // when
-        const result = baseConfigSchema(PKG).safeParse({
+        const result = saleorConfigSchema(PKG).safeParse({
           ENVIRONMENT: "production",
           NODE_ENV: "production",
           VITE_SALEOR_APP_TOKEN: "token",
@@ -152,13 +152,28 @@ describe("schema", () => {
       // given the shape every app builds its config with
       const schema = z
         .object({ CONFIG_KEY: z.string().default("nimara-config") })
-        .and(baseConfigSchema(PKG));
+        .and(saleorConfigSchema(PKG));
 
       // when / then
       expect(schema.parse({ ENVIRONMENT: "test" })).toMatchObject({
         CONFIG_KEY: "nimara-config",
         DISPLAY_NAME: "Feed generator",
       });
+    });
+  });
+
+  describe("coreConfigSchema", () => {
+    it("derives the app's identity, with no Saleor fields", () => {
+      // when
+      const config = coreConfigSchema(PKG).parse({ ENVIRONMENT: "test" });
+
+      // then
+      expect(config).toMatchObject({
+        DISPLAY_NAME: "Feed generator",
+        NAME: "@nimara/feed-generator",
+      });
+      expect(config).not.toHaveProperty("ALLOWED_DOMAINS");
+      expect(config).not.toHaveProperty("VITE_SALEOR_APP_TOKEN");
     });
   });
 });

--- a/packages/lib/src/config/schema.ts
+++ b/packages/lib/src/config/schema.ts
@@ -11,62 +11,88 @@ export type PackageInfo = {
   version: string;
 };
 
-// Apps extend it: `z.object({ ... }).and(baseConfigSchema(pkg))`.
-export const baseConfigSchema = (
+const coreFields = z.object({
+  ENVIRONMENT: z.string(),
+  NODE_ENV: z
+    .enum(["development", "test", "production"])
+    .default("development"),
+  FETCH_TIMEOUT: z
+    .number()
+    .default(10000)
+    .describe("Fetch timeout in milliseconds."),
+  SENTRY_DSN: blankAsUnset(
+    z.url().trim().optional().describe("Sentry DSN, enables reporting."),
+  ),
+  BASE_PATH: z
+    .string()
+    .regex(
+      /^(\/[^/\s]+)*$/,
+      "BASE_PATH must be empty or a prefix like `/my-app`",
+    )
+    .default("")
+    .describe(
+      "Path prefix the app is served under. Empty at root; set per app in dev (`/<app>`) and via env for a sub-path deployment.",
+    ),
+});
+
+const saleorFields = z.object({
+  // Fail closed: an emptied allow list admits nobody, not everybody.
+  ALLOWED_DOMAINS: z
+    .preprocess(
+      // Read straight off `process.env`, so the list arrives as one string.
+      (value) =>
+        typeof value === "string"
+          ? value
+              .split(",")
+              .map((domain) => domain.trim().toLowerCase())
+              .filter(Boolean)
+          : value,
+      z.array(z.string()),
+    )
+    .default([])
+    .describe(
+      "Comma-separated Saleor domains allowed to install the app. Supports wildcards.",
+    ),
+  VITE_SALEOR_APP_TOKEN: blankAsUnset(
+    z
+      .string()
+      .trim()
+      .min(1)
+      .optional()
+      .describe(
+        "A short-lived staff JWT with MANAGE_APPS, for running the Dashboard UI outside the Saleor iframe. Copy it from a real Dashboard session's Authorization header. A long-lived API token authenticates GraphQL fine but is not a JWT, so it will not verify here.",
+      ),
+  ),
+});
+
+const finalize =
+  <Data extends { NODE_ENV: "development" | "production" | "test" }>(
+    pkg: PackageInfo,
+  ) =>
+  (data: Data) => ({
+    AUTHOR: pkg.author,
+    DESCRIPTION: pkg.description,
+    DISPLAY_NAME: getAppDisplayName(pkg.name),
+    IS_DEVELOPMENT: data.NODE_ENV === "development",
+    IS_PRODUCTION: data.NODE_ENV === "production",
+    IS_TEST: data.NODE_ENV === "test",
+    NAME: pkg.name,
+    RELEASE: `${pkg.name}@${pkg.version}`.toLowerCase(),
+    VERSION: pkg.version,
+    ...data,
+  });
+
+// A service with no Saleor integration at all: no per-tenant fields.
+export const coreConfigSchema = (pkg: PackageInfo) =>
+  coreFields.transform(finalize(pkg));
+
+// A Saleor app extends it: `z.object({ ... }).and(saleorConfigSchema(pkg))`.
+export const saleorConfigSchema = (
   pkg: PackageInfo,
   { singleTenant = false }: { singleTenant?: boolean } = {},
 ) =>
-  z
-    .object({
-      ENVIRONMENT: z.string(),
-      NODE_ENV: z
-        .enum(["development", "test", "production"])
-        .default("development"),
-      // Fail closed: an emptied allow list admits nobody, not everybody.
-      ALLOWED_DOMAINS: z
-        .preprocess(
-          // Read straight off `process.env`, so the list arrives as one string.
-          (value) =>
-            typeof value === "string"
-              ? value
-                  .split(",")
-                  .map((domain) => domain.trim().toLowerCase())
-                  .filter(Boolean)
-              : value,
-          z.array(z.string()),
-        )
-        .default([])
-        .describe(
-          "Comma-separated Saleor domains allowed to install the app. Supports wildcards.",
-        ),
-      FETCH_TIMEOUT: z
-        .number()
-        .default(10000)
-        .describe("Fetch timeout in milliseconds."),
-      SENTRY_DSN: blankAsUnset(
-        z.url().trim().optional().describe("Sentry DSN, enables reporting."),
-      ),
-      VITE_SALEOR_APP_TOKEN: blankAsUnset(
-        z
-          .string()
-          .trim()
-          .min(1)
-          .optional()
-          .describe(
-            "A short-lived staff JWT with MANAGE_APPS, for running the Dashboard UI outside the Saleor iframe. Copy it from a real Dashboard session's Authorization header. A long-lived API token authenticates GraphQL fine but is not a JWT, so it will not verify here.",
-          ),
-      ),
-      BASE_PATH: z
-        .string()
-        .regex(
-          /^(\/[^/\s]+)*$/,
-          "BASE_PATH must be empty or a prefix like `/my-app`",
-        )
-        .default("")
-        .describe(
-          "Path prefix the app is served under. Empty at root; set per app in dev (`/<app>`) and via env for a sub-path deployment.",
-        ),
-    })
+  coreFields
+    .and(saleorFields)
     .superRefine((data, ctx) => {
       if (singleTenant && data.ALLOWED_DOMAINS.length !== 1) {
         ctx.addIssue({
@@ -101,15 +127,4 @@ export const baseConfigSchema = (
         });
       }
     })
-    .transform((data) => ({
-      AUTHOR: pkg.author,
-      DESCRIPTION: pkg.description,
-      DISPLAY_NAME: getAppDisplayName(pkg.name),
-      IS_DEVELOPMENT: data.NODE_ENV === "development",
-      IS_PRODUCTION: data.NODE_ENV === "production",
-      IS_TEST: data.NODE_ENV === "test",
-      NAME: pkg.name,
-      RELEASE: `${pkg.name}@${pkg.version}`.toLowerCase(),
-      VERSION: pkg.version,
-      ...data,
-    }));
+    .transform(finalize(pkg));

--- a/packages/lib/src/config/service.test.ts
+++ b/packages/lib/src/config/service.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import {
+  prepareCoreServiceConfig,
   prepareServiceConfig,
   prepareSingleTenantServiceConfig,
 } from "./service";
@@ -93,6 +94,19 @@ describe("config service", () => {
           }),
         ),
       ).toThrow();
+    });
+  });
+
+  describe("prepareCoreServiceConfig", () => {
+    it("names the service after the directory it is parsed from", () => {
+      // when
+      const config = withEnv({ ENVIRONMENT: "test" }, () =>
+        prepareCoreServiceConfig({ moduleUrl: MODULE_URL, pkg: PKG }),
+      );
+
+      // then
+      expect(config.SERVICE).toBe("handler");
+      expect(config).not.toHaveProperty("ALLOWED_DOMAINS");
     });
   });
 });

--- a/packages/lib/src/config/service.ts
+++ b/packages/lib/src/config/service.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url";
 
 import { z } from "zod";
 
-import { baseConfigSchema, type PackageInfo } from "#root/config/schema";
+import { type PackageInfo, saleorConfigSchema } from "#root/config/schema";
 import { type AnyZodSchema } from "#root/zod/types";
 import { prepareConfig } from "#root/zod/util";
 
@@ -30,7 +30,7 @@ const prepareForService = <Schema extends AnyZodSchema>(
     serverOnly: true,
     schema: z
       .object({ SERVICE: z.string().default(service) })
-      .and(baseConfigSchema(pkg, { singleTenant }))
+      .and(saleorConfigSchema(pkg, { singleTenant }))
       .and(schema),
   });
 };

--- a/packages/lib/src/config/service.ts
+++ b/packages/lib/src/config/service.ts
@@ -3,7 +3,11 @@ import { fileURLToPath } from "node:url";
 
 import { z } from "zod";
 
-import { type PackageInfo, saleorConfigSchema } from "#root/config/schema";
+import {
+  coreConfigSchema,
+  type PackageInfo,
+  saleorConfigSchema,
+} from "#root/config/schema";
 import { type AnyZodSchema } from "#root/zod/types";
 import { prepareConfig } from "#root/zod/util";
 
@@ -58,4 +62,25 @@ export const prepareSingleTenantServiceConfig = <
   const [saleorDomain] = config.ALLOWED_DOMAINS as [string];
 
   return { ...config, SALEOR_DOMAIN: saleorDomain };
+};
+
+// For a service with no Saleor integration at all: no per-tenant fields.
+export const prepareCoreServiceConfig = <
+  Schema extends AnyZodSchema = AnyZodSchema,
+>({
+  moduleUrl,
+  pkg,
+  // Intersecting an empty object is a no-op, for a service that adds nothing.
+  schema = z.object({}) as unknown as Schema,
+}: ServiceConfigInput<Schema>) => {
+  const service = basename(dirname(fileURLToPath(moduleUrl)));
+
+  return prepareConfig({
+    name: service,
+    serverOnly: true,
+    schema: z
+      .object({ SERVICE: z.string().default(service) })
+      .and(coreConfigSchema(pkg))
+      .and(schema),
+  });
 };

--- a/templates/app/README.blank.md
+++ b/templates/app/README.blank.md
@@ -1,0 +1,94 @@
+# app-template
+
+Hono on the server. Generated apps start as a copy of this one, so what is
+here is what every app begins with.
+
+Generate one instead of copying by hand:
+
+```bash
+pnpm gen app
+```
+
+## Running it
+
+```bash
+pnpm env:init   # copies .env.example to .env
+pnpm dev
+```
+
+`env:init` refuses to overwrite an existing `.env`.
+
+Set at least `ENVIRONMENT`.
+
+## Layout
+
+```
+src/services/<service>/    one service, one entry point, one Lambda
+  entry-server.ts          the Hono app; `handler` is its Lambda binding
+  entry-queue.ts           a queue service instead; exports `handler` alone
+  entry-event.ts           an invoked service instead; exports `handler` alone
+  config.ts                this service's environment
+  container.ts             the app container, built from that config
+src/container/             wiring; everything is lazy
+src/infrastructure/        outward calls
+```
+
+`src/services/*` is scanned by the build and by the dev server, so adding a
+directory with an entry file is all it takes to add a service. A single HTTP
+service is served at `/`, several under `/<service>`. A service holds one entry
+file or the other, never both: one service is one deployed unit. Both generators
+ask what to call it.
+
+## Adding a service
+
+```bash
+pnpm gen service
+```
+
+It copies this template's service under the name you give and points the
+imports that reached into the old one at the new one. It asks what the
+service serves — HTTP, a queue, or a direct invoke — so one app can hold
+several kinds side by side. A queue or an invoked service is offered only
+where the app's build target can drive one.
+
+## Queue services
+
+A deployment drives a queue service from an SQS event source mapping. In
+development the dev server stands in for that mapping, so what runs locally is
+the deployed code path.
+
+Start LocalStack from the repository root:
+
+```bash
+docker compose up -d localstack
+```
+
+The dev server reads `<SERVICE>_QUEUE_URL` — `CONSUMER_QUEUE_URL` for a service
+named `consumer` — and creates that queue on LocalStack before it polls. Name a
+queue in `SQS_QUEUES` when it has to exist before anything reads it, such as one
+another app publishes to:
+
+```bash
+SQS_QUEUES=feed-sync-consumer docker compose up -d localstack
+```
+
+The AWS variables arrive in `.env.example` with the service. `AWS_ENDPOINT_URL`
+is what points the client at LocalStack, and what lets the dev server create a
+queue at all — against a real account it creates nothing, because a typo in a
+queue URL would silently make a queue rather than fail.
+
+Building a queue service for Vercel fails: nothing there polls a queue, so it
+would build and never run. Use `BUILD_TARGET=node`.
+
+## Event services
+
+An invoked service is driven by whatever calls it directly — a scheduled
+rule, another function, or a hand-run invoke — never by a request. `handler`
+takes the event and an invocation context whose `getRemainingTimeInMillis`
+gives the work its budget, so a long job checkpoints and invokes itself again
+rather than running until Lambda kills it.
+
+In development the dev server stands in for that trigger at
+`POST /<service>/invoke`, with a 60-second budget. Building an event service
+for Vercel fails the same way a queue service does: nothing there invokes a
+function directly. Use `BUILD_TARGET=node`.

--- a/templates/app/src/container/index.blank.ts
+++ b/templates/app/src/container/index.blank.ts
@@ -1,0 +1,15 @@
+import { createContainer } from "iti";
+
+import { getLogger } from "@nimara/infrastructure/logging/service";
+
+export type AppConfig = { NAME: string };
+
+export const createAppContainer = <Config extends AppConfig>(config: Config) =>
+  createContainer().add({
+    config: () => config,
+    logger: () => getLogger({ name: config.NAME }),
+  });
+
+export type AppContainer<Config extends AppConfig = AppConfig> = ReturnType<
+  typeof createAppContainer<Config>
+>;

--- a/templates/app/src/services/handler/config.common.ts
+++ b/templates/app/src/services/handler/config.common.ts
@@ -1,0 +1,8 @@
+import { prepareCoreServiceConfig } from "@nimara/lib/config/service";
+
+import packageJson from "../../../package.json";
+
+export const APP_CONFIG = prepareCoreServiceConfig({
+  moduleUrl: import.meta.url,
+  pkg: packageJson,
+});

--- a/templates/app/src/services/handler/entry-server.blank.ts
+++ b/templates/app/src/services/handler/entry-server.blank.ts
@@ -1,0 +1,37 @@
+import { Hono } from "hono";
+import { handle } from "hono/aws-lambda";
+import { requestId } from "hono/request-id";
+
+import { errorHandler } from "@nimara/lib/hono/error/handler";
+import { healthCheckMiddleware } from "@nimara/lib/hono/middleware/health-check";
+import { loggingMiddleware } from "@nimara/lib/hono/middleware/logging";
+import { requestOriginMiddleware } from "@nimara/lib/hono/middleware/request-origin";
+import { initSentry } from "@nimara/lib/reporting/sentry/instrument";
+
+import { container } from "@/services/handler/container";
+
+const { config, logger } = container.items;
+
+initSentry({
+  dsn: config.SENTRY_DSN,
+  environment: config.ENVIRONMENT,
+  release: config.RELEASE,
+});
+
+const app = new Hono()
+  .onError(errorHandler)
+  .basePath(config.BASE_PATH as "/")
+  .use(requestId())
+  .use(loggingMiddleware(logger))
+  .use(requestOriginMiddleware({ basePath: config.BASE_PATH }))
+  .use(healthCheckMiddleware({ basePath: config.BASE_PATH }))
+  .get("/", (context) =>
+    context.text(`${config.DISPLAY_NAME} ${config.VERSION}.`),
+  );
+
+export type AppType = typeof app;
+
+// `app` for the Vercel preset and the dev server, `handler` for AWS Lambda.
+const handler = handle(app);
+
+export { app, handler };

--- a/turbo/generators/config.ts
+++ b/turbo/generators/config.ts
@@ -40,8 +40,9 @@ const resolveKind = ({
 
 type ServiceAnswers = {
   app: string;
-  kind: AppKind;
+  dashboard?: boolean;
   name: string;
+  trigger?: ServiceTrigger;
   turbo: { paths: { root: string } };
 };
 
@@ -114,14 +115,20 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
 
   plop.setGenerator("service", {
     description: "Add a service to an app that already exists",
-    prompts: [prompts.app, prompts.kind, prompts.serviceName],
+    prompts: [
+      prompts.app,
+      prompts.trigger,
+      prompts.serviceName,
+      prompts.dashboard,
+    ],
     actions: [
       async (answers) => {
-        const { app, kind, name, turbo } = answers as ServiceAnswers;
+        const { app, dashboard, name, trigger, turbo } =
+          answers as ServiceAnswers;
 
         const serviceDir = await createService({
           app,
-          kind,
+          kind: resolveKind({ dashboard, trigger }),
           name,
           root: turbo.paths.root,
         });

--- a/turbo/generators/config.ts
+++ b/turbo/generators/config.ts
@@ -2,20 +2,40 @@ import { execFileSync } from "node:child_process";
 
 import { type PlopTypes } from "@turbo/gen";
 
+import { type ServiceTrigger } from "@nimara/tooling/entry-points";
+
 import { createApp } from "./src/create-app.ts";
 import { createService } from "./src/create-service.ts";
 import { type AppKind, type BuildTarget, type Tenancy } from "./src/names.ts";
 import * as prompts from "./src/prompts.ts";
 
 type Answers = {
+  dashboard?: boolean;
   description: string;
-  kind: AppKind;
   name: string;
   port: string;
   service: string;
   target: BuildTarget;
   tenancy: Tenancy;
+  trigger?: ServiceTrigger;
   turbo: { paths: { root: string } };
+};
+
+// The trigger and dashboard prompts stand in for the old single `kind` choice.
+const resolveKind = ({
+  dashboard,
+  trigger,
+}: {
+  dashboard?: boolean;
+  trigger?: ServiceTrigger;
+}): AppKind => {
+  const effectiveTrigger = prompts.resolveTrigger({ trigger });
+
+  if (effectiveTrigger !== "http") {
+    return effectiveTrigger;
+  }
+
+  return dashboard ? "dashboard" : "http";
 };
 
 type ServiceAnswers = {
@@ -49,28 +69,30 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
     prompts: [
       prompts.appName,
       prompts.description,
-      prompts.tenancy,
       prompts.target,
-      prompts.kind,
+      prompts.trigger,
       prompts.service,
+      prompts.tenancy,
+      prompts.dashboard,
       prompts.port,
     ],
     actions: [
       async (answers) => {
         const {
+          dashboard,
           description,
-          kind,
           name,
           port,
           service,
           target,
           tenancy,
+          trigger,
           turbo,
         } = answers as Answers;
 
         const destination = await createApp({
           description,
-          kind,
+          kind: resolveKind({ dashboard, trigger }),
           name,
           port,
           root: turbo.paths.root,

--- a/turbo/generators/config.ts
+++ b/turbo/generators/config.ts
@@ -6,17 +6,23 @@ import { type ServiceTrigger } from "@nimara/tooling/entry-points";
 
 import { createApp } from "./src/create-app.ts";
 import { createService } from "./src/create-service.ts";
-import { type AppKind, type BuildTarget, type Tenancy } from "./src/names.ts";
+import {
+  type AppKind,
+  type BuildTarget,
+  type Integration,
+  type Tenancy,
+} from "./src/names.ts";
 import * as prompts from "./src/prompts.ts";
 
 type Answers = {
   dashboard?: boolean;
   description: string;
+  integration: Integration;
   name: string;
   port: string;
   service: string;
   target: BuildTarget;
-  tenancy: Tenancy;
+  tenancy?: Tenancy;
   trigger?: ServiceTrigger;
   turbo: { paths: { root: string } };
 };
@@ -73,6 +79,7 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
       prompts.target,
       prompts.trigger,
       prompts.service,
+      prompts.integration,
       prompts.tenancy,
       prompts.dashboard,
       prompts.port,
@@ -82,6 +89,7 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
         const {
           dashboard,
           description,
+          integration,
           name,
           port,
           service,
@@ -93,6 +101,7 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
 
         const destination = await createApp({
           description,
+          integration,
           kind: resolveKind({ dashboard, trigger }),
           name,
           port,

--- a/turbo/generators/src/config-provider.ts
+++ b/turbo/generators/src/config-provider.ts
@@ -25,7 +25,7 @@ const NODE_STORE = `: awsSecretsManagerConfigItem({
               logger: ctx.logger,
             }),`;
 
-const DEV_BOOTSTRAP = `if (process.env.APP_CONFIG_STORE_PATH) {
+export const DEV_BOOTSTRAP = `if (process.env.APP_CONFIG_STORE_PATH) {
   const { ensureSecretsManager } =
     await import("@nimara/tooling/aws/secrets-manager");
 

--- a/turbo/generators/src/create-app.test.ts
+++ b/turbo/generators/src/create-app.test.ts
@@ -82,11 +82,13 @@ const write = async (path: string, contents: string) => {
 };
 
 const generate = ({
+  integration = "saleor",
   kind = "dashboard",
   service = "handler",
   target = "vercel",
   tenancy = "multi",
 }: {
+  integration?: "blank" | "saleor";
   kind?: AppKind;
   service?: string;
   target?: "node" | "vercel";
@@ -94,6 +96,7 @@ const generate = ({
 } = {}) =>
   createApp({
     description: "Keeps a feed in step with Saleor",
+    integration,
     kind,
     name: "feed-sync",
     port: "8010",
@@ -248,6 +251,7 @@ describe("create-app", () => {
     // when
     const destination = await createApp({
       description: "Anything",
+      integration: "saleor",
       kind: "dashboard",
       name: "  Feed Sync!  ",
       port: "8010",

--- a/turbo/generators/src/create-app.ts
+++ b/turbo/generators/src/create-app.ts
@@ -112,7 +112,7 @@ const copyTemplate = ({
         return false;
       }
 
-      if (integration === "blank" && isSaleorPath(path)) {
+      if (integration === "blank" && isSaleorPath(path, { appPaths: true })) {
         return false;
       }
 
@@ -251,11 +251,8 @@ export const createApp = async ({
     to: serviceName,
   });
 
-  /**
-   * Ahead of rewriteText: its TEMPLATE_NAME substitution would otherwise
-   * touch `app-template-config`, the default APP_CONFIG_STORE_PATH value
-   * this cuts out of .env.example, and break its exact-text match.
-   */
+  // Ahead of rewriteText, whose TEMPLATE_NAME substitution would touch
+  // `app-template-config` first and break this cut's exact-text match.
   if (integration === "blank") {
     await removeAppIntegration(destination);
   }
@@ -282,11 +279,8 @@ export const createApp = async ({
     });
   }
 
-  /**
-   * Unwires what the copy left out. A queue service never had a dashboard. A
-   * blank service already got the fully cut-down entry-server.blank.ts, which
-   * this cut's replacements would not find text to match against.
-   */
+  // Unwires what the copy left out. A queue service never had a dashboard.
+  // A blank service already got the cut-down entry-server.blank.ts.
   if (kind === "http" && integration === "saleor") {
     await removeServiceDashboard(serviceDir);
   }

--- a/turbo/generators/src/create-app.ts
+++ b/turbo/generators/src/create-app.ts
@@ -9,8 +9,14 @@ import {
 } from "./dashboard.ts";
 import { mergeServiceEnv } from "./env.ts";
 import {
+  blankVariants,
+  isSaleorPath,
+  removeAppIntegration,
+} from "./integration.ts";
+import {
   type AppKind,
   type BuildTarget,
+  type Integration,
   requireKindForTarget,
   TEMPLATE_NAME,
   TEMPLATE_PORT,
@@ -35,13 +41,14 @@ export const NOT_COPIED = new Set([
 
 export type CreateAppInput = {
   description: string;
+  integration: Integration;
   kind: AppKind;
   name: string;
   port: string;
   root: string;
   service: string;
   target: BuildTarget;
-  tenancy: Tenancy;
+  tenancy?: Tenancy;
 };
 
 // An app deployed elsewhere should not carry another platform's config.
@@ -71,16 +78,23 @@ AWS_REGION=eu-central-1`;
 
 const copyTemplate = ({
   destination,
+  integration,
   kind,
   source,
   target,
 }: {
   destination: string;
+  integration: Integration;
   kind: AppKind;
   source: string;
   target: BuildTarget;
-}) =>
-  cp(source, destination, {
+}) => {
+  // Never copied under their own name: swapped in wholesale after, or dropped.
+  const blankSources = new Set(
+    blankVariants(TEMPLATE_SERVICES[kind]).map(([blankSource]) => blankSource),
+  );
+
+  return cp(source, destination, {
     errorOnExist: true,
     filter: (entry) => {
       const name = basename(entry);
@@ -93,6 +107,14 @@ const copyTemplate = ({
       }
 
       const path = relative(source, entry).split(sep).join("/");
+
+      if (blankSources.has(path)) {
+        return false;
+      }
+
+      if (integration === "blank" && isSaleorPath(path)) {
+        return false;
+      }
 
       if (
         unusedServicePaths(kind).some(
@@ -107,6 +129,7 @@ const copyTemplate = ({
     force: false,
     recursive: true,
   });
+};
 
 const rewritePackageJson = async ({
   description,
@@ -147,14 +170,20 @@ const rewriteText = async ({
   name: string;
   port: string;
   target: BuildTarget;
-  tenancy: Tenancy;
+  tenancy?: Tenancy;
 }) => {
   const contents = await readFile(file, "utf8");
   let result = contents
     .replaceAll(TEMPLATE_NAME, name)
     .replaceAll(TEMPLATE_PORT, port)
-    .replace(/^BUILD_TARGET=.*$/m, `BUILD_TARGET=${target}`)
-    .replace(ALLOWED_DOMAINS_DOC.multi, ALLOWED_DOMAINS_DOC[tenancy]);
+    .replace(/^BUILD_TARGET=.*$/m, `BUILD_TARGET=${target}`);
+
+  if (tenancy) {
+    result = result.replace(
+      ALLOWED_DOMAINS_DOC.multi,
+      ALLOWED_DOMAINS_DOC[tenancy],
+    );
+  }
 
   if (target !== "node") {
     result = result.replace(LOCALSTACK_ENV_DOC, "");
@@ -166,6 +195,7 @@ const rewriteText = async ({
 // An app reads the rest from its own package.json, so nothing else is substituted.
 export const createApp = async ({
   description,
+  integration,
   kind,
   name,
   port,
@@ -176,18 +206,43 @@ export const createApp = async ({
 }: CreateAppInput) => {
   requireKindForTarget({ kind, target });
 
+  if (integration === "saleor" && !tenancy) {
+    throw new Error("A Saleor app needs a tenancy: multi or single.");
+  }
+
+  if (integration === "blank" && kind === "dashboard") {
+    throw new Error("A blank app has no Saleor dashboard to add a page to.");
+  }
+
   // `--args` skips the prompts that would have filtered these.
   const appName = toDirectoryName(name);
   const serviceName = toDirectoryName(service);
   const destination = join(root, "apps", appName);
   const serviceDir = join(destination, "src", "services", serviceName);
+  const templateRoot = join(root, "templates", "app");
 
   await copyTemplate({
     destination,
+    integration,
     kind,
-    source: join(root, "templates", "app"),
+    source: templateRoot,
     target,
   });
+
+  // Ahead of renameService, whose scan of the service directory must find it.
+  if (integration === "blank") {
+    for (const [blankSource, blankDestination] of blankVariants(
+      TEMPLATE_SERVICES[kind],
+    )) {
+      await cp(
+        join(templateRoot, blankSource),
+        join(destination, blankDestination),
+        {
+          force: true,
+        },
+      );
+    }
+  }
 
   // Ahead of the rest, so everything after it names the service the app has.
   await renameService({
@@ -195,6 +250,15 @@ export const createApp = async ({
     from: TEMPLATE_SERVICES[kind],
     to: serviceName,
   });
+
+  /**
+   * Ahead of rewriteText: its TEMPLATE_NAME substitution would otherwise
+   * touch `app-template-config`, the default APP_CONFIG_STORE_PATH value
+   * this cuts out of .env.example, and break its exact-text match.
+   */
+  if (integration === "blank") {
+    await removeAppIntegration(destination);
+  }
 
   await rewritePackageJson({
     description,
@@ -207,7 +271,7 @@ export const createApp = async ({
   for (const file of [
     "README.md",
     ".env.example",
-    "src/domain/app-config.ts",
+    ...(integration === "saleor" ? ["src/domain/app-config.ts"] : []),
   ]) {
     await rewriteText({
       file: join(destination, file),
@@ -218,8 +282,12 @@ export const createApp = async ({
     });
   }
 
-  // Unwires what the copy left out. A queue service never had a dashboard.
-  if (kind === "http") {
+  /**
+   * Unwires what the copy left out. A queue service never had a dashboard. A
+   * blank service already got the fully cut-down entry-server.blank.ts, which
+   * this cut's replacements would not find text to match against.
+   */
+  if (kind === "http" && integration === "saleor") {
     await removeServiceDashboard(serviceDir);
   }
 
@@ -233,9 +301,10 @@ export const createApp = async ({
 
   await mergeServiceEnv({ appDir: destination, serviceDir });
 
-  await applyTenancy({ appDir: destination, tenancy });
-
-  await applyConfigProvider({ appDir: destination, target });
+  if (integration === "saleor") {
+    await applyTenancy({ appDir: destination, tenancy: tenancy! });
+    await applyConfigProvider({ appDir: destination, target });
+  }
 
   return destination;
 };

--- a/turbo/generators/src/create-service.ts
+++ b/turbo/generators/src/create-service.ts
@@ -10,6 +10,11 @@ import {
 } from "./dashboard.ts";
 import { mergeServiceEnv } from "./env.ts";
 import {
+  blankVariants,
+  detectIntegration,
+  isSaleorPath,
+} from "./integration.ts";
+import {
   type AppKind,
   requireKindForTarget,
   TEMPLATE_SERVICES,
@@ -67,24 +72,43 @@ export const createService = async ({
   const appDir = join(root, "apps", app);
   const serviceDir = join(appDir, "src", "services", serviceName);
 
+  // Inherited, never asked again: the services share one container/config.
+  const integration = detectIntegration(appDir);
+
+  if (integration === "blank" && kind === "dashboard") {
+    throw new Error("A blank app has no Saleor dashboard to add a page to.");
+  }
+
   const templateService = TEMPLATE_SERVICES[kind];
-  const source = join(
-    root,
-    "templates",
-    "app",
-    "src",
-    "services",
-    templateService,
+  const templateRoot = join(root, "templates", "app");
+  const source = join(templateRoot, "src", "services", templateService);
+
+  const servicePrefix = `src/services/${templateService}/`;
+  const blankVariantPairs = blankVariants(templateService)
+    .filter(([, destination]) => destination.startsWith(servicePrefix))
+    .map(([blankSource, destination]): [string, string] => [
+      blankSource,
+      destination.slice(servicePrefix.length),
+    ]);
+  const blankSourceNames = new Set(
+    blankVariantPairs.map(([blankSource]) => basename(blankSource)),
   );
 
   await cp(source, serviceDir, {
     errorOnExist: true,
     filter: (entry) => {
-      if (NOT_COPIED.has(basename(entry))) {
+      if (
+        NOT_COPIED.has(basename(entry)) ||
+        blankSourceNames.has(basename(entry))
+      ) {
         return false;
       }
 
       const path = relative(source, entry).split(sep).join("/");
+
+      if (integration === "blank" && isSaleorPath(path)) {
+        return false;
+      }
 
       return kind === "dashboard" || !isDashboardPath(path);
     },
@@ -92,8 +116,17 @@ export const createService = async ({
     recursive: true,
   });
 
+  // Ahead of rewriteServiceImports, whose scan of serviceDir must find it.
+  if (integration === "blank") {
+    for (const [blankSource, destination] of blankVariantPairs) {
+      await cp(join(templateRoot, blankSource), join(serviceDir, destination), {
+        force: true,
+      });
+    }
+  }
+
   // Before the rewrite: the lines it cuts still name the template's service.
-  if (kind === "http") {
+  if (kind === "http" && integration === "saleor") {
     await removeServiceDashboard(serviceDir);
   }
 
@@ -114,8 +147,9 @@ export const createService = async ({
 
   await mergeServiceEnv({ appDir, serviceDir });
 
-  // Inherited, never asked again: the services share one `.env`.
-  await applyTenancy({ appDir, tenancy: await detectTenancy(appDir) });
+  if (integration === "saleor") {
+    await applyTenancy({ appDir, tenancy: await detectTenancy(appDir) });
+  }
 
   return serviceDir;
 };

--- a/turbo/generators/src/integration.ts
+++ b/turbo/generators/src/integration.ts
@@ -1,8 +1,9 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { DEV_BOOTSTRAP } from "./config-provider.ts";
-import { TEMPLATE_SERVICE } from "./names.ts";
+import { type Integration, TEMPLATE_SERVICE } from "./names.ts";
 
 const APP_SALEOR_PATHS = [
   ".graphqlrc.ts",
@@ -13,19 +14,61 @@ const APP_SALEOR_PATHS = [
   "src/use-cases",
 ];
 
-// A blank app never has a dashboard either, so nothing under api survives.
+// Blank never has a dashboard either, so nothing under api survives.
 const SERVICE_SALEOR_PATHS = ["api", "logo.png"];
 
 const isUnder = (path: string, prefix: string) =>
   path === prefix || path.startsWith(`${prefix}/`);
 
-export const isSaleorPath = (path: string) =>
+/**
+ * `appPaths` mirrors `isDashboardPath`: `createApp` copies the whole
+ * template, `createService` only the one service directory.
+ */
+export const isSaleorPath = (
+  path: string,
+  { appPaths = false }: { appPaths?: boolean } = {},
+) =>
   [
-    ...APP_SALEOR_PATHS,
-    ...SERVICE_SALEOR_PATHS.map(
-      (servicePath) => `src/services/${TEMPLATE_SERVICE}/${servicePath}`,
-    ),
+    ...(appPaths
+      ? [
+          ...APP_SALEOR_PATHS,
+          ...SERVICE_SALEOR_PATHS.map(
+            (servicePath) => `src/services/${TEMPLATE_SERVICE}/${servicePath}`,
+          ),
+        ]
+      : SERVICE_SALEOR_PATHS),
   ].some((prefix) => isUnder(path, prefix));
+
+/**
+ * Synchronous like `detectBuildTarget`: a prompt's `when` runs before plop
+ * can await anything.
+ */
+export const detectIntegration = (appDir: string): Integration => {
+  const servicesDir = join(appDir, "src", "services");
+
+  if (!existsSync(servicesDir)) {
+    return "saleor";
+  }
+
+  const entries = readdirSync(servicesDir, {
+    recursive: true,
+    withFileTypes: true,
+  });
+
+  for (const entry of entries) {
+    if (!entry.isFile() || entry.name !== "config.ts") {
+      continue;
+    }
+
+    const contents = readFileSync(join(entry.parentPath, entry.name), "utf8");
+
+    if (contents.includes("prepareCoreServiceConfig")) {
+      return "blank";
+    }
+  }
+
+  return "saleor";
+};
 
 const rewrite = async ({
   path,

--- a/turbo/generators/src/integration.ts
+++ b/turbo/generators/src/integration.ts
@@ -89,3 +89,66 @@ export const removeServiceIntegration = (
       ],
     ],
   });
+
+/**
+ * Only `handler/entry-server.ts` ever mounts the Saleor manifest. Run this
+ * after `removeServiceDashboard`, whose cut this one's replacements assume.
+ */
+export const removeServiceManifest = (serviceDir: string) =>
+  rewrite({
+    path: join(serviceDir, "entry-server.ts"),
+    replacements: [
+      [
+        [
+          'import { container } from "@/services/handler/container";',
+          'import logo from "@/services/handler/logo.png?inline";',
+          "",
+          'import { saleorRoutes } from "./api/rest/saleor";',
+          "",
+          "const { config, logger } = container.items;",
+        ].join("\n"),
+        [
+          'import { container } from "@/services/handler/container";',
+          "",
+          "const { config, logger } = container.items;",
+        ].join("\n"),
+      ],
+      [
+        [
+          "const { config, logger } = container.items;",
+          'const LOGO = Buffer.from(logo.split(",")[1] ?? "", "base64");',
+          "",
+          "initSentry({",
+        ].join("\n"),
+        [
+          "const { config, logger } = container.items;",
+          "",
+          "initSentry({",
+        ].join("\n"),
+      ],
+      [
+        [
+          '  .get("/logo.png", (context) =>',
+          '    context.body(LOGO, 200, { "content-type": "image/png" }),',
+          "  )",
+          "  /**",
+          "   * Saleor opens `appUrl`, which is the app's root. A dashboard, where the app",
+          "   * has one, is mounted above and answers first.",
+          "   */",
+          '  .get("/", (context) =>',
+        ].join("\n"),
+        '  .get("/", (context) =>',
+      ],
+      [
+        [
+          "  )",
+          "  /**",
+          "   * Nested routes must be defined at the end for proper type inference for",
+          "   * hono/client.",
+          "   */",
+          '  .route("/api/saleor", saleorRoutes);',
+        ].join("\n"),
+        "  );",
+      ],
+    ],
+  });

--- a/turbo/generators/src/integration.ts
+++ b/turbo/generators/src/integration.ts
@@ -1,15 +1,20 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
+import { DEV_BOOTSTRAP } from "./config-provider.ts";
 import { TEMPLATE_SERVICE } from "./names.ts";
 
 const APP_SALEOR_PATHS = [
-  "src/domain/app-config.ts",
+  ".graphqlrc.ts",
+  "codegen.ts",
+  "src/domain",
   "src/graphql",
   "src/infrastructure/saleor",
+  "src/use-cases",
 ];
 
-const SERVICE_SALEOR_PATHS = ["api/rest/saleor", "logo.png"];
+// A blank app never has a dashboard either, so nothing under api survives.
+const SERVICE_SALEOR_PATHS = ["api", "logo.png"];
 
 const isUnder = (path: string, prefix: string) =>
   path === prefix || path.startsWith(`${prefix}/`);
@@ -197,10 +202,18 @@ const removeVitestIntegration = (appDir: string) =>
     ],
   });
 
+// No config store to bootstrap locally, on any target.
+const removeDevServerIntegration = (appDir: string) =>
+  rewrite({
+    path: join(appDir, "src", "dev-server.ts"),
+    replacements: [[DEV_BOOTSTRAP, ""]],
+  });
+
 // container/config/entry-server/README are swapped by copyTemplate, not rewritten here.
 export const removeAppIntegration = async (appDir: string) => {
   await removePackageIntegration(appDir);
   await removeEnvIntegration(appDir);
   await removeTurboIntegration(appDir);
   await removeVitestIntegration(appDir);
+  await removeDevServerIntegration(appDir);
 };

--- a/turbo/generators/src/integration.ts
+++ b/turbo/generators/src/integration.ts
@@ -1,0 +1,91 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { TEMPLATE_SERVICE } from "./names.ts";
+
+const rewrite = async ({
+  path,
+  replacements,
+}: {
+  path: string;
+  replacements: [from: string, to: string][];
+}) => {
+  let contents = await readFile(path, "utf8");
+
+  for (const [from, to] of replacements) {
+    if (!contents.includes(from)) {
+      throw new Error(`Expected ${JSON.stringify(from)} in ${path}.`);
+    }
+
+    contents = contents.replace(from, to);
+  }
+
+  await writeFile(path, contents);
+};
+
+// consumer/config.ts and event/config.ts start out byte-identical to this.
+const SHARED_CONFIG = [
+  'import { prepareServiceConfig } from "@nimara/lib/config/service";',
+  "",
+  'import { appConfigSchema } from "@/domain/app-config";',
+  "",
+  'import packageJson from "../../../package.json";',
+  "",
+  "export const APP_CONFIG = prepareServiceConfig({",
+  "  moduleUrl: import.meta.url,",
+  "  pkg: packageJson,",
+  "  schema: appConfigSchema,",
+  "});",
+  "",
+].join("\n");
+
+// handler/config.ts also carries APP_ID, the Saleor manifest's app id.
+const HANDLER_CONFIG = [
+  'import { prepareServiceConfig } from "@nimara/lib/config/service";',
+  "",
+  'import { appConfigSchema } from "@/domain/app-config";',
+  "",
+  'import packageJson from "../../../package.json";',
+  "",
+  "const parsed = prepareServiceConfig({",
+  "  moduleUrl: import.meta.url,",
+  "  pkg: packageJson,",
+  "  schema: appConfigSchema,",
+  "});",
+  "",
+  "export const APP_CONFIG = {",
+  "  ...parsed,",
+  "  APP_ID: `${parsed.ENVIRONMENT}.${parsed.NAME}`,",
+  "};",
+  "",
+].join("\n");
+
+const BLANK_CONFIG = [
+  'import { prepareCoreServiceConfig } from "@nimara/lib/config/service";',
+  "",
+  'import packageJson from "../../../package.json";',
+  "",
+  "export const APP_CONFIG = prepareCoreServiceConfig({",
+  "  moduleUrl: import.meta.url,",
+  "  pkg: packageJson,",
+  "});",
+  "",
+].join("\n");
+
+/**
+ * Neither template service reads a per-tenant Saleor config, so both collapse
+ * onto the same blank shape once `appConfigSchema` is gone.
+ */
+export const removeServiceIntegration = (
+  serviceDir: string,
+  templateService: string,
+) =>
+  rewrite({
+    path: join(serviceDir, "config.ts"),
+    replacements: [
+      [
+        templateService === TEMPLATE_SERVICE ? HANDLER_CONFIG : SHARED_CONFIG,
+        BLANK_CONFIG,
+      ],
+    ],
+  });

--- a/turbo/generators/src/integration.ts
+++ b/turbo/generators/src/integration.ts
@@ -3,6 +3,28 @@ import { join } from "node:path";
 
 import { TEMPLATE_SERVICE } from "./names.ts";
 
+// What the app around it holds only for its Saleor integration.
+const APP_SALEOR_PATHS = [
+  "src/domain/app-config.ts",
+  "src/graphql",
+  "src/infrastructure/saleor",
+];
+
+// What handler alone holds, because it alone mounts the Saleor manifest.
+const SERVICE_SALEOR_PATHS = ["api/rest/saleor", "logo.png"];
+
+const isUnder = (path: string, prefix: string) =>
+  path === prefix || path.startsWith(`${prefix}/`);
+
+// Whether a path inside a copy exists only to serve the Saleor integration.
+export const isSaleorPath = (path: string) =>
+  [
+    ...APP_SALEOR_PATHS,
+    ...SERVICE_SALEOR_PATHS.map(
+      (servicePath) => `src/services/${TEMPLATE_SERVICE}/${servicePath}`,
+    ),
+  ].some((prefix) => isUnder(path, prefix));
+
 const rewrite = async ({
   path,
   replacements,

--- a/turbo/generators/src/integration.ts
+++ b/turbo/generators/src/integration.ts
@@ -3,20 +3,17 @@ import { join } from "node:path";
 
 import { TEMPLATE_SERVICE } from "./names.ts";
 
-// What the app around it holds only for its Saleor integration.
 const APP_SALEOR_PATHS = [
   "src/domain/app-config.ts",
   "src/graphql",
   "src/infrastructure/saleor",
 ];
 
-// What handler alone holds, because it alone mounts the Saleor manifest.
 const SERVICE_SALEOR_PATHS = ["api/rest/saleor", "logo.png"];
 
 const isUnder = (path: string, prefix: string) =>
   path === prefix || path.startsWith(`${prefix}/`);
 
-// Whether a path inside a copy exists only to serve the Saleor integration.
 export const isSaleorPath = (path: string) =>
   [
     ...APP_SALEOR_PATHS,
@@ -45,132 +42,165 @@ const rewrite = async ({
   await writeFile(path, contents);
 };
 
-// consumer/config.ts and event/config.ts start out byte-identical to this.
-const SHARED_CONFIG = [
-  'import { prepareServiceConfig } from "@nimara/lib/config/service";',
-  "",
-  'import { appConfigSchema } from "@/domain/app-config";',
-  "",
-  'import packageJson from "../../../package.json";',
-  "",
-  "export const APP_CONFIG = prepareServiceConfig({",
-  "  moduleUrl: import.meta.url,",
-  "  pkg: packageJson,",
-  "  schema: appConfigSchema,",
-  "});",
-  "",
-].join("\n");
-
-// handler/config.ts also carries APP_ID, the Saleor manifest's app id.
-const HANDLER_CONFIG = [
-  'import { prepareServiceConfig } from "@nimara/lib/config/service";',
-  "",
-  'import { appConfigSchema } from "@/domain/app-config";',
-  "",
-  'import packageJson from "../../../package.json";',
-  "",
-  "const parsed = prepareServiceConfig({",
-  "  moduleUrl: import.meta.url,",
-  "  pkg: packageJson,",
-  "  schema: appConfigSchema,",
-  "});",
-  "",
-  "export const APP_CONFIG = {",
-  "  ...parsed,",
-  "  APP_ID: `${parsed.ENVIRONMENT}.${parsed.NAME}`,",
-  "};",
-  "",
-].join("\n");
-
-const BLANK_CONFIG = [
-  'import { prepareCoreServiceConfig } from "@nimara/lib/config/service";',
-  "",
-  'import packageJson from "../../../package.json";',
-  "",
-  "export const APP_CONFIG = prepareCoreServiceConfig({",
-  "  moduleUrl: import.meta.url,",
-  "  pkg: packageJson,",
-  "});",
-  "",
-].join("\n");
-
 /**
- * Neither template service reads a per-tenant Saleor config, so both collapse
- * onto the same blank shape once `appConfigSchema` is gone.
+ * All three services read the same `config.common.ts`; it lives under
+ * `handler` only because handler always exists, not because it is handler's.
+ * `entry-server.ts` is handler-only — a queue or event service has no
+ * manifest to drop.
  */
-export const removeServiceIntegration = (
-  serviceDir: string,
+export const blankVariants = (
   templateService: string,
-) =>
+): [source: string, destination: string][] => [
+  ["src/container/index.blank.ts", "src/container/index.ts"],
+  ["README.blank.md", "README.md"],
+  [
+    `src/services/${TEMPLATE_SERVICE}/config.common.ts`,
+    `src/services/${templateService}/config.ts`,
+  ],
+  ...(templateService === TEMPLATE_SERVICE
+    ? ([
+        [
+          `src/services/${templateService}/entry-server.blank.ts`,
+          `src/services/${templateService}/entry-server.ts`,
+        ],
+      ] as [source: string, destination: string][])
+    : []),
+];
+
+const CODEGEN_DEPENDENCIES = [
+  "@graphql-codegen/cli",
+  "@graphql-typed-document-node/core",
+  "@nimara/codegen",
+];
+
+const removePackageIntegration = async (appDir: string) => {
+  const path = join(appDir, "package.json");
+  const pkg = JSON.parse(await readFile(path, "utf8")) as {
+    dependencies: Record<string, string>;
+    devDependencies: Record<string, string>;
+    scripts: Record<string, string>;
+  };
+
+  delete pkg.dependencies["@saleor/app-sdk"];
+
+  for (const name of CODEGEN_DEPENDENCIES) {
+    delete pkg.devDependencies[name];
+  }
+
+  delete pkg.scripts.codegen;
+
+  await writeFile(path, `${JSON.stringify(pkg, null, 2)}\n`);
+};
+
+const removeEnvIntegration = (appDir: string) =>
   rewrite({
-    path: join(serviceDir, "config.ts"),
+    path: join(appDir, ".env.example"),
     replacements: [
       [
-        templateService === TEMPLATE_SERVICE ? HANDLER_CONFIG : SHARED_CONFIG,
-        BLANK_CONFIG,
+        "# local | development | staging | production. Also the manifest app-id prefix.\nENVIRONMENT=local",
+        "# local | development | staging | production.\nENVIRONMENT=local",
+      ],
+      [
+        [
+          "ENVIRONMENT=local",
+          "",
+          "# Comma-separated Saleor domains allowed to install the app, e.g.",
+          "# store.saleor.cloud. Empty allows none. Wildcards (`*`, `*.saleor.cloud`)",
+          "# widen it and belong in local development only.",
+          "ALLOWED_DOMAINS=",
+          "",
+          "# Path prefix",
+        ].join("\n"),
+        ["ENVIRONMENT=local", "", "# Path prefix"].join("\n"),
+      ],
+      [
+        [
+          "SENTRY_DSN=",
+          "",
+          "# Key the config is stored under. Optional; defaults in code.",
+          "APP_CONFIG_STORE_PATH=app-template-config",
+          "",
+          "# Optional: KMS key the store encrypts with. Empty uses the AWS default key.",
+          "APP_CONFIG_ENCRYPTION_KEY=",
+          "",
+          "# The Saleor whose schema `pnpm codegen` generates the client from.",
+          "NEXT_PUBLIC_SALEOR_API_URL=",
+          "",
+          "# LocalStack only.",
+        ].join("\n"),
+        ["SENTRY_DSN=", "", "# LocalStack only."].join("\n"),
       ],
     ],
   });
 
-/**
- * Only `handler/entry-server.ts` ever mounts the Saleor manifest. Run this
- * after `removeServiceDashboard`, whose cut this one's replacements assume.
- */
-export const removeServiceManifest = (serviceDir: string) =>
+const removeTurboIntegration = (appDir: string) =>
   rewrite({
-    path: join(serviceDir, "entry-server.ts"),
+    path: join(appDir, "turbo.json"),
     replacements: [
       [
         [
-          'import { container } from "@/services/handler/container";',
-          'import logo from "@/services/handler/logo.png?inline";',
-          "",
-          'import { saleorRoutes } from "./api/rest/saleor";',
-          "",
-          "const { config, logger } = container.items;",
+          '      "env": [',
+          '        "BUILD_TARGET",',
+          '        "ENVIRONMENT",',
+          '        "BASE_PATH",',
+          '        "ALLOWED_DOMAINS",',
+          '        "APP_CONFIG_STORE_PATH",',
+          '        "APP_CONFIG_ENCRYPTION_KEY",',
+          '        "SENTRY_DSN",',
+          '        "SENTRY_ORG",',
+          '        "SENTRY_PROJECT",',
+          '        "SENTRY_DEBUG"',
+          "      ],",
+          '      "passThroughEnv": ["SENTRY_AUTH_TOKEN"]',
+          "    },",
+          '    "codegen": {',
+          '      "outputs": ["src/graphql/generated/**"],',
+          '      "inputs": ["src/**/*.graphql", "codegen.ts"],',
+          '      "env": ["NEXT_PUBLIC_SALEOR_API_URL"]',
+          "    }",
         ].join("\n"),
         [
-          'import { container } from "@/services/handler/container";',
-          "",
-          "const { config, logger } = container.items;",
+          '      "env": [',
+          '        "BUILD_TARGET",',
+          '        "ENVIRONMENT",',
+          '        "BASE_PATH",',
+          '        "SENTRY_DSN",',
+          '        "SENTRY_ORG",',
+          '        "SENTRY_PROJECT",',
+          '        "SENTRY_DEBUG"',
+          "      ],",
+          '      "passThroughEnv": ["SENTRY_AUTH_TOKEN"]',
+          "    }",
         ].join("\n"),
-      ],
-      [
-        [
-          "const { config, logger } = container.items;",
-          'const LOGO = Buffer.from(logo.split(",")[1] ?? "", "base64");',
-          "",
-          "initSentry({",
-        ].join("\n"),
-        [
-          "const { config, logger } = container.items;",
-          "",
-          "initSentry({",
-        ].join("\n"),
-      ],
-      [
-        [
-          '  .get("/logo.png", (context) =>',
-          '    context.body(LOGO, 200, { "content-type": "image/png" }),',
-          "  )",
-          "  /**",
-          "   * Saleor opens `appUrl`, which is the app's root. A dashboard, where the app",
-          "   * has one, is mounted above and answers first.",
-          "   */",
-          '  .get("/", (context) =>',
-        ].join("\n"),
-        '  .get("/", (context) =>',
-      ],
-      [
-        [
-          "  )",
-          "  /**",
-          "   * Nested routes must be defined at the end for proper type inference for",
-          "   * hono/client.",
-          "   */",
-          '  .route("/api/saleor", saleorRoutes);',
-        ].join("\n"),
-        "  );",
       ],
     ],
   });
+
+const removeVitestIntegration = (appDir: string) =>
+  rewrite({
+    path: join(appDir, "vitest.config.ts"),
+    replacements: [
+      [
+        [
+          "      // Enough for the app to boot in a test; a real value belongs in `.env`.",
+          "      // `local` is what puts the config store on disk instead of in a cloud.",
+          '      ENVIRONMENT: "local",',
+          '      ALLOWED_DOMAINS: "saleor.example.com",',
+          "      ...process.env,",
+        ].join("\n"),
+        [
+          "      // Enough for the app to boot in a test; a real value belongs in `.env`.",
+          '      ENVIRONMENT: "local",',
+          "      ...process.env,",
+        ].join("\n"),
+      ],
+    ],
+  });
+
+// container/config/entry-server/README are swapped by copyTemplate, not rewritten here.
+export const removeAppIntegration = async (appDir: string) => {
+  await removePackageIntegration(appDir);
+  await removeEnvIntegration(appDir);
+  await removeTurboIntegration(appDir);
+  await removeVitestIntegration(appDir);
+};

--- a/turbo/generators/src/names.ts
+++ b/turbo/generators/src/names.ts
@@ -1,4 +1,7 @@
-import { VERCEL_UNSUPPORTED_TRIGGERS } from "@nimara/tooling/entry-points";
+import {
+  type ServiceTrigger,
+  VERCEL_UNSUPPORTED_TRIGGERS,
+} from "@nimara/tooling/entry-points";
 
 export const TEMPLATE_NAME = "app-template";
 
@@ -72,3 +75,11 @@ export const requireKindForTarget = ({
 export const TENANCIES = ["multi", "single"] as const;
 
 export type Tenancy = (typeof TENANCIES)[number];
+
+export const TRIGGERS: readonly ServiceTrigger[] = ["http", "queue", "event"];
+
+export const triggersForTarget = (target: BuildTarget): ServiceTrigger[] =>
+  TRIGGERS.filter(
+    (trigger) =>
+      target !== "vercel" || !VERCEL_UNSUPPORTED_TRIGGERS.includes(trigger),
+  );

--- a/turbo/generators/src/names.ts
+++ b/turbo/generators/src/names.ts
@@ -83,3 +83,7 @@ export const triggersForTarget = (target: BuildTarget): ServiceTrigger[] =>
     (trigger) =>
       target !== "vercel" || !VERCEL_UNSUPPORTED_TRIGGERS.includes(trigger),
   );
+
+export const INTEGRATIONS = ["blank", "saleor"] as const;
+
+export type Integration = (typeof INTEGRATIONS)[number];

--- a/turbo/generators/src/prompts.ts
+++ b/turbo/generators/src/prompts.ts
@@ -130,6 +130,11 @@ export const trigger: PlopTypes.PromptQuestion = {
     resolveTarget(answers) !== "vercel",
 };
 
+// Vercel forces the trigger prompt to be skipped, but it still only runs HTTP.
+export const resolveTrigger = (answers: {
+  trigger?: ServiceTrigger;
+}): ServiceTrigger => answers.trigger ?? "http";
+
 // Only an HTTP-triggered service has anything to serve a settings page from.
 export const dashboard: PlopTypes.PromptQuestion = {
   choices: [
@@ -140,12 +145,15 @@ export const dashboard: PlopTypes.PromptQuestion = {
   message: "Add the Dashboard settings page?",
   name: "dashboard",
   type: "list",
-  when: (answers: { trigger?: ServiceTrigger }) => answers.trigger === "http",
+  when: (answers: { trigger?: ServiceTrigger }) =>
+    resolveTrigger(answers) === "http",
 };
 
 // Asked separately from the app's own name: `src/services/<service>`.
 export const service: PlopTypes.PromptQuestion = {
-  default: (answers: { kind: AppKind }) => TEMPLATE_SERVICES[answers.kind],
+  // `dashboard` is answered later, but it never changes the service directory.
+  default: (answers: { trigger?: ServiceTrigger }) =>
+    TEMPLATE_SERVICES[resolveTrigger(answers)],
   filter: toDirectoryName,
   message: "Service name (becomes src/services/<name>):",
   name: "service",

--- a/turbo/generators/src/prompts.ts
+++ b/turbo/generators/src/prompts.ts
@@ -9,6 +9,8 @@ import { listApps } from "./create-service.ts";
 import {
   BUILD_TARGETS,
   type BuildTarget,
+  type Integration,
+  INTEGRATIONS,
   TEMPLATE_SERVICES,
   TENANCIES,
   type Tenancy,
@@ -48,6 +50,20 @@ export const description: PlopTypes.PromptQuestion = {
     input.trim().length > 0 || "A description is required.",
 };
 
+export const integration: PlopTypes.PromptQuestion = {
+  choices: [
+    { name: "_blank — no Saleor integration at all", value: "blank" },
+    {
+      name: "Saleor — a Saleor app: manifest, webhooks, dashboard",
+      value: "saleor",
+    },
+  ] satisfies { name: string; value: Integration }[],
+  default: INTEGRATIONS[1],
+  message: "What does it integrate with?",
+  name: "integration",
+  type: "list",
+};
+
 export const tenancy: PlopTypes.PromptQuestion = {
   choices: [
     { name: "multi — installable by many Saleor instances", value: "multi" },
@@ -60,6 +76,8 @@ export const tenancy: PlopTypes.PromptQuestion = {
   message: "How many Saleor instances does it serve?",
   name: "tenancy",
   type: "list",
+  when: (answers: { integration?: Integration }) =>
+    answers.integration === "saleor",
 };
 
 /**
@@ -113,7 +131,7 @@ export const resolveTrigger = (answers: {
   trigger?: ServiceTrigger;
 }): ServiceTrigger => answers.trigger ?? "http";
 
-// Only an HTTP-triggered service has anything to serve a settings page from.
+// Only an HTTP-triggered Saleor service has a Saleor dashboard to add a page to.
 export const dashboard: PlopTypes.PromptQuestion = {
   choices: [
     { name: "Yes", value: true },
@@ -123,8 +141,8 @@ export const dashboard: PlopTypes.PromptQuestion = {
   message: "Add the Dashboard settings page?",
   name: "dashboard",
   type: "list",
-  when: (answers: { trigger?: ServiceTrigger }) =>
-    resolveTrigger(answers) === "http",
+  when: (answers: { integration?: Integration; trigger?: ServiceTrigger }) =>
+    resolveTrigger(answers) === "http" && answers.integration === "saleor",
 };
 
 // Asked separately from the app's own name: `src/services/<service>`.

--- a/turbo/generators/src/prompts.ts
+++ b/turbo/generators/src/prompts.ts
@@ -7,11 +7,8 @@ import { type ServiceTrigger } from "@nimara/tooling/entry-points";
 
 import { listApps } from "./create-service.ts";
 import {
-  type AppKind,
   BUILD_TARGETS,
   type BuildTarget,
-  KINDS,
-  kindsForTarget,
   TEMPLATE_SERVICES,
   TENANCIES,
   type Tenancy,
@@ -76,31 +73,6 @@ const resolveTarget = (answers: {
   answers.target ??
   detectBuildTarget({ app: answers.app ?? "", root: process.cwd() });
 
-const KIND_LABELS: Record<AppKind, string> = {
-  dashboard: "dashboard — HTTP, with a settings page in Saleor",
-  event: "event — invoked by a schedule or another function, no HTTP",
-  http: "http — HTTP only: webhooks and API",
-  queue: "queue — an SQS consumer, no HTTP",
-};
-
-export const kind: PlopTypes.PromptQuestion = {
-  /**
-   * Plop matches a bypassed `--args` answer against `choices`, which here is a
-   * function. Taking the answer as given leaves the pairing to `createApp` and
-   * `createService`, which see both the kind and the target.
-   */
-  bypass: (input: string) => input,
-  choices: (answers: { app?: string; target?: BuildTarget }) =>
-    kindsForTarget(resolveTarget(answers)).map((value) => ({
-      name: KIND_LABELS[value],
-      value,
-    })),
-  default: KINDS[0],
-  message: "What does the service serve?",
-  name: "kind",
-  type: "list",
-};
-
 export const target: PlopTypes.PromptQuestion = {
   choices: [...BUILD_TARGETS],
   default: BUILD_TARGETS[0],
@@ -117,6 +89,12 @@ const TRIGGER_LABELS: Record<ServiceTrigger, string> = {
 
 // Vercel only runs HTTP, so this is skipped there instead of offered with one choice.
 export const trigger: PlopTypes.PromptQuestion = {
+  /**
+   * Plop matches a bypassed `--args` answer against `choices`, which here is a
+   * function. Taking the answer as given leaves the pairing to `createApp` and
+   * `createService`, which see both the kind and the target.
+   */
+  bypass: (input: string) => input,
   choices: (answers: { app?: string; target?: BuildTarget }) =>
     triggersForTarget(resolveTarget(answers)).map((value) => ({
       name: TRIGGER_LABELS[value],
@@ -178,7 +156,9 @@ export const app: PlopTypes.PromptQuestion = {
 };
 
 export const serviceName: PlopTypes.PromptQuestion = {
-  default: (answers: { kind: AppKind }) => TEMPLATE_SERVICES[answers.kind],
+  // `dashboard` is answered later, but it never changes the service directory.
+  default: (answers: { trigger?: ServiceTrigger }) =>
+    TEMPLATE_SERVICES[resolveTrigger(answers)],
   filter: toDirectoryName,
   message: "Service name (becomes src/services/<name>):",
   name: "name",

--- a/turbo/generators/src/prompts.ts
+++ b/turbo/generators/src/prompts.ts
@@ -3,6 +3,8 @@ import { join } from "node:path";
 
 import { type PlopTypes } from "@turbo/gen";
 
+import { type ServiceTrigger } from "@nimara/tooling/entry-points";
+
 import { listApps } from "./create-service.ts";
 import {
   type AppKind,
@@ -14,6 +16,8 @@ import {
   TENANCIES,
   type Tenancy,
   toDirectoryName,
+  TRIGGERS,
+  triggersForTarget,
   validateName,
 } from "./names.ts";
 import { detectBuildTarget } from "./target.ts";
@@ -61,6 +65,17 @@ export const tenancy: PlopTypes.PromptQuestion = {
   type: "list",
 };
 
+/**
+ * A new app answers `target` outright; a service added later has no `target`
+ * prompt of its own, so it inherits what its app already chose.
+ */
+const resolveTarget = (answers: {
+  app?: string;
+  target?: BuildTarget;
+}): BuildTarget =>
+  answers.target ??
+  detectBuildTarget({ app: answers.app ?? "", root: process.cwd() });
+
 const KIND_LABELS: Record<AppKind, string> = {
   dashboard: "dashboard — HTTP, with a settings page in Saleor",
   event: "event — invoked by a schedule or another function, no HTTP",
@@ -75,15 +90,11 @@ export const kind: PlopTypes.PromptQuestion = {
    * `createService`, which see both the kind and the target.
    */
   bypass: (input: string) => input,
-  /**
-   * Offers what the target can run. A new app answers `target` outright; a
-   * service added later inherits what its app chose.
-   */
   choices: (answers: { app?: string; target?: BuildTarget }) =>
-    kindsForTarget(
-      answers.target ??
-        detectBuildTarget({ app: answers.app ?? "", root: process.cwd() }),
-    ).map((value) => ({ name: KIND_LABELS[value], value })),
+    kindsForTarget(resolveTarget(answers)).map((value) => ({
+      name: KIND_LABELS[value],
+      value,
+    })),
   default: KINDS[0],
   message: "What does the service serve?",
   name: "kind",
@@ -96,6 +107,27 @@ export const target: PlopTypes.PromptQuestion = {
   message: "Where does it run?",
   name: "target",
   type: "list",
+};
+
+const TRIGGER_LABELS: Record<ServiceTrigger, string> = {
+  event: "INVOKE",
+  http: "HTTP",
+  queue: "QUEUE",
+};
+
+// Vercel only runs HTTP, so this is skipped there instead of offered with one choice.
+export const trigger: PlopTypes.PromptQuestion = {
+  choices: (answers: { app?: string; target?: BuildTarget }) =>
+    triggersForTarget(resolveTarget(answers)).map((value) => ({
+      name: TRIGGER_LABELS[value],
+      value,
+    })),
+  default: TRIGGERS[0],
+  message: "What triggers it?",
+  name: "trigger",
+  type: "list",
+  when: (answers: { app?: string; target?: BuildTarget }) =>
+    resolveTarget(answers) !== "vercel",
 };
 
 // Asked separately from the app's own name: `src/services/<service>`.

--- a/turbo/generators/src/prompts.ts
+++ b/turbo/generators/src/prompts.ts
@@ -6,6 +6,7 @@ import { type PlopTypes } from "@turbo/gen";
 import { type ServiceTrigger } from "@nimara/tooling/entry-points";
 
 import { listApps } from "./create-service.ts";
+import { detectIntegration } from "./integration.ts";
 import {
   BUILD_TARGETS,
   type BuildTarget,
@@ -131,6 +132,17 @@ export const resolveTrigger = (answers: {
   trigger?: ServiceTrigger;
 }): ServiceTrigger => answers.trigger ?? "http";
 
+/**
+ * A new app answers `integration` outright; a service added later has no
+ * `integration` prompt of its own, so it inherits what its app already chose.
+ */
+const resolveIntegration = (answers: {
+  app?: string;
+  integration?: Integration;
+}): Integration =>
+  answers.integration ??
+  detectIntegration(join(process.cwd(), "apps", answers.app ?? ""));
+
 // Only an HTTP-triggered Saleor service has a Saleor dashboard to add a page to.
 export const dashboard: PlopTypes.PromptQuestion = {
   choices: [
@@ -141,8 +153,13 @@ export const dashboard: PlopTypes.PromptQuestion = {
   message: "Add the Dashboard settings page?",
   name: "dashboard",
   type: "list",
-  when: (answers: { integration?: Integration; trigger?: ServiceTrigger }) =>
-    resolveTrigger(answers) === "http" && answers.integration === "saleor",
+  when: (answers: {
+    app?: string;
+    integration?: Integration;
+    trigger?: ServiceTrigger;
+  }) =>
+    resolveTrigger(answers) === "http" &&
+    resolveIntegration(answers) === "saleor",
 };
 
 // Asked separately from the app's own name: `src/services/<service>`.

--- a/turbo/generators/src/prompts.ts
+++ b/turbo/generators/src/prompts.ts
@@ -130,6 +130,19 @@ export const trigger: PlopTypes.PromptQuestion = {
     resolveTarget(answers) !== "vercel",
 };
 
+// Only an HTTP-triggered service has anything to serve a settings page from.
+export const dashboard: PlopTypes.PromptQuestion = {
+  choices: [
+    { name: "Yes", value: true },
+    { name: "No", value: false },
+  ],
+  default: false,
+  message: "Add the Dashboard settings page?",
+  name: "dashboard",
+  type: "list",
+  when: (answers: { trigger?: ServiceTrigger }) => answers.trigger === "http",
+};
+
 // Asked separately from the app's own name: `src/services/<service>`.
 export const service: PlopTypes.PromptQuestion = {
   default: (answers: { kind: AppKind }) => TEMPLATE_SERVICES[answers.kind],

--- a/turbo/generators/src/prompts.ts
+++ b/turbo/generators/src/prompts.ts
@@ -39,7 +39,8 @@ export const appName: PlopTypes.PromptQuestion = {
 };
 
 export const description: PlopTypes.PromptQuestion = {
-  message: "Description (shown in the Saleor dashboard):",
+  message:
+    "Description (goes to package.json, used later in the app manifest):",
   name: "description",
   type: "input",
   validate: (input: string) =>
@@ -92,7 +93,7 @@ export const kind: PlopTypes.PromptQuestion = {
 export const target: PlopTypes.PromptQuestion = {
   choices: [...BUILD_TARGETS],
   default: BUILD_TARGETS[0],
-  message: "What is the deployment target?",
+  message: "Where does it run?",
   name: "target",
   type: "list",
 };


### PR DESCRIPTION
## Summary

Reworks the `turbo gen app`/`turbo gen service` prompt flow to match the updated flow diagram, and adds a `_blank` integration option — an AWS Lambda/Vercel service generated with zero Saleor coupling, alongside the existing Saleor app path.

**Slice 1 — prompt reorder (complete):**
- New order: name → description → target (relabeled "Where does it run?") → trigger (HTTP/QUEUE/INVOKE, skipped + forced HTTP on Vercel) → service name → tenancy → dashboard (yes/no) → port
- `kind` is now derived from `trigger` + `dashboard` instead of asked directly
- Mirrored into the `service` sub-generator

**Slice 2 — blank integration (building blocks + app generator wiring complete):**
- `@nimara/lib`: split `baseConfigSchema` into `coreConfigSchema` (generic) + `saleorConfigSchema` (Saleor-specific), added `prepareCoreServiceConfig`; corrected `packages/lib/CLAUDE.md`'s charter, which overstated the package's Saleor coupling
- New `integration` prompt (`_blank`/`Saleor`), gates `tenancy` and `dashboard`
- Blank services get full sibling files (`container/index.blank.ts`, `config.common.ts`, `entry-server.blank.ts`, `README.blank.md`) swapped in by the generator, rather than computed diffs, since they end up ~100% different from the Saleor shape anyway
- `isSaleorPath`/`blankVariants` wired into both `createApp` and `createService`'s copy filters
- `detectIntegration` (mirrors `detectBuildTarget`): the `service` sub-generator inherits an existing app's integration instead of re-asking
- Verified end-to-end against the real template (not just the existing fixture-based unit tests): blank queue app, blank HTTP app, Saleor dashboard app, and adding a second service to each — all produce correct, compiling output

**Still open (follow-up, not in this PR):**
- Blank → Saleor upgrade path: today, a blank app's integration is a one-way lock (by design — a deployed Saleor manifest can't be safely un-integrated, but a still-blank app has nothing committed yet and could safely upgrade). Design is worked out (restore app-level Saleor files/deps, restore every *existing sibling* service's config — not just the new one, since all services share one container/config type — reusing the existing `applyTenancy`/`removeServiceDashboard` rather than new content), not yet implemented.
- Test fixtures for the blank path in `create-app.test.ts`/`create-service.test.ts` (existing fixtures only cover Saleor; blank correctness so far verified via manual end-to-end generation, not automated).

## Test plan
- [x] `pnpm --filter @nimara/generators test` (57 tests) and `pnpm --filter @nimara/lib test` pass
- [x] Type-check and lint clean across `turbo/generators`, `templates/app`, `packages/lib`
- [x] Manual end-to-end generation verified for: blank queue app, blank HTTP app, Saleor dashboard app, adding a service to each (including the blank+dashboard guard)
- [ ] Automated test coverage for the blank path (tracked as follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)